### PR TITLE
Add JWT secret env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Grading behavior is defined per assignment and supports:
 
 The system is fully Dockerized for simple setup using `docker-compose`.
 
+### Environment Variables
+The backend expects two variables to be set (usually via a `.env` file):
+
+- `DATABASE_URL` – PostgreSQL connection string
+- `JWT_SECRET` – secret used to sign authentication tokens
+
 ### Services
 - **frontend**: Svelte SPA
 - **backend**: Gin-based Go API

--- a/backend/auth.go
+++ b/backend/auth.go
@@ -5,13 +5,24 @@ import (
 	"time"
 
 	"log"
+	"os"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/joho/godotenv"
 	"golang.org/x/crypto/bcrypt"
 )
 
-var jwtSecret = []byte("supersecret-change-me")
+var jwtSecret []byte
+
+func InitAuth() {
+	_ = godotenv.Load()
+	secret := os.Getenv("JWT_SECRET")
+	if secret == "" {
+		log.Fatal("JWT_SECRET is not set")
+	}
+	jwtSecret = []byte(secret)
+}
 
 type registerReq struct {
 	Email    string `json:"email" binding:"required,email"`

--- a/backend/main.go
+++ b/backend/main.go
@@ -33,8 +33,9 @@ func ensureAdmin() {
 }
 
 func main() {
-	// 1) Init DB
+	// 1) Init DB and auth
 	InitDB()
+	InitAuth()
 	ensureAdmin()
 
 	// 2) Router


### PR DESCRIPTION
## Summary
- load JWT secret from `JWT_SECRET` env var with check
- initialize auth in `main.go`
- document required environment variables

## Testing
- `go vet ./...` *(fails: directory prefix does not contain module)*

------
https://chatgpt.com/codex/tasks/task_e_6843434b4f9083219a696a1a073b68c8