### PR TITLE
Fix teacher class query and add test

### DIFF
--- a/backend/models.go
+++ b/backend/models.go
@@ -164,12 +164,9 @@ func AddStudentsToClass(classID int, studentIDs []int) error {
 func ListClassesForTeacher(teacherID int) ([]Class, error) {
 	var cls []Class
 	err := DB.Select(&cls, `
-        SELECT c.id, c.name, u.email AS teacher_email, c.created_at
-  		FROM classes c
-  		JOIN users      u  ON u.id = c.teacher_id
-  		JOIN class_students cs ON cs.class_id = c.id
- 		WHERE cs.student_id = $1
- 		ORDER BY c.created_at DESC`, teacherID)
+                SELECT * FROM classes
+                 WHERE teacher_id = $1
+                 ORDER BY created_at DESC`, teacherID)
 	return cls, err
 }
 

--- a/backend/models_test.go
+++ b/backend/models_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+)
+
+func TestListClassesForTeacher(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to open sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	DB = sqlx.NewDb(db, "sqlmock")
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{"id", "name", "teacher_id", "created_at", "updated_at"}).
+		AddRow(1, "Class A", 7, now, now)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM classes WHERE teacher_id = $1 ORDER BY created_at DESC`)).
+		WithArgs(7).WillReturnRows(rows)
+
+	cls, err := ListClassesForTeacher(7)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cls) != 1 {
+		t.Fatalf("expected 1 class, got %d", len(cls))
+	}
+	if cls[0].TeacherID != 7 {
+		t.Fatalf("wrong teacher id: %d", cls[0].TeacherID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- correct class listing query to filter by teacher_id
- add a regression test using sqlmock to ensure teachers only see their classes

## Testing
- `go test ./...` *(fails: no required module provides packages)*

------
https://chatgpt.com/codex/tasks/task_e_684343677bd88321bcc500b6cc0df794