### PR TITLE
Change backend port to 22946

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -94,8 +94,8 @@ func main() {
 
 	}
 
-	log.Println("🚀 Server running on http://localhost:8080")
-	if err := r.Run(":8080"); err != nil {
-		log.Fatalf("could not start server: %v", err)
-	}
+        log.Println("🚀 Server running on http://localhost:22946")
+        if err := r.Run(":22946"); err != nil {
+                log.Fatalf("could not start server: %v", err)
+        }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,9 +6,9 @@ export default defineConfig({
   plugins: [svelte()],
   server: {
     proxy: {
-      '/api': 'http://localhost:8080',
-      '/register': 'http://localhost:8080',
-      '/login': 'http://localhost:8080'
+      '/api': 'http://localhost:22946',
+      '/register': 'http://localhost:22946',
+      '/login': 'http://localhost:22946'
     }
   }
 })


### PR DESCRIPTION
## Summary
- update backend port to `22946`
- update Vite proxy to reflect new backend port

## Testing
- `go test ./...` in `backend`
- `npm install` and `npm run check` *(fails: cannot find module 'node-fetch' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845970afa1c83218576aa889c17ca24