### PR TITLE
Move admin credentials to env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,12 @@ Grading behavior is defined per assignment and supports:
 The system is fully Dockerized for simple setup using `docker-compose`.
 
 ### Environment Variables
-The backend expects two variables to be set (usually via a `.env` file):
+The backend expects several variables to be set (usually via a `.env` file):
 
 - `DATABASE_URL` – PostgreSQL connection string
 - `JWT_SECRET` – secret used to sign authentication tokens
+- `ADMIN_EMAIL` – email for the seeded administrator account
+- `ADMIN_PASSWORD` – password for the seeded administrator account
 
 You can copy `backend/.env.example` and adjust it for your environment.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,4 @@
 DATABASE_URL=postgres://codegrader_user:supersecret@127.0.0.1:48812/codegrader_db?sslmode=disable
 JWT_SECRET=change_me
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=admin123

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,7 @@ module github.com/herajda/code-grader/backend
 go 1.23.8
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/gin-gonic/gin v1.10.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/jmoiron/sqlx v1.4.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/bytedance/sonic v1.13.2 h1:8/H1FempDZqC4VqjptGo14QQlJx8VdZJegxs6wwfqpQ=
 github.com/bytedance/sonic v1.13.2/go.mod h1:o68xyaF9u2gvVBuGHPlUVCy+ZfmNNO5ETf1+KgkJhz4=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
@@ -40,6 +42,7 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=

--- a/backend/main.go
+++ b/backend/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -12,10 +13,14 @@ import (
 
 // seed a single admin so you’re never locked out
 func ensureAdmin() {
-	const (
-		email    = "admin@example.com"
+	email := os.Getenv("ADMIN_EMAIL")
+	if email == "" {
+		email = "admin@example.com"
+	}
+	password := os.Getenv("ADMIN_PASSWORD")
+	if password == "" {
 		password = "admin123"
-	)
+	}
 	var exists bool
 	if err := DB.Get(&exists,
 		`SELECT EXISTS(SELECT 1 FROM users WHERE email=$1)`, email); err != nil {
@@ -94,8 +99,8 @@ func main() {
 
 	}
 
-        log.Println("🚀 Server running on http://localhost:22946")
-        if err := r.Run(":22946"); err != nil {
-                log.Fatalf("could not start server: %v", err)
-        }
+	log.Println("🚀 Server running on http://localhost:22946")
+	if err := r.Run(":22946"); err != nil {
+		log.Fatalf("could not start server: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
- add environment variables for seeding the administrator
- document new variables in README
- provide example values in `.env.example`
- update Go code to read `ADMIN_EMAIL` and `ADMIN_PASSWORD`
- update Go modules for sqlmock to run tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845a166c6108321a387f219241c7916