### PR TITLE
Fix a11y issue in TeacherClasses

### DIFF
--- a/frontend/src/routes/TeacherClasses.svelte
+++ b/frontend/src/routes/TeacherClasses.svelte
@@ -33,9 +33,12 @@
   
   <ul>
     {#each classes as c}
-      <li on:click={()=>push(`/classes/${c.id}`)}
-          style="cursor:pointer;text-decoration:underline">
-        {c.name} &nbsp; <small>({new Date(c.created_at).toLocaleDateString()})</small>
+      <li>
+        <button
+           on:click={()=>push(`/classes/${c.id}`)}
+           style="background:none;border:none;padding:0;cursor:pointer;text-decoration:underline;color:inherit;font:inherit">
+          {c.name} &nbsp; <small>({new Date(c.created_at).toLocaleDateString()})</small>
+        </button>
       </li>
     {/each}
     {#if !classes.length}<p>No classes yet.</p>{/if}


### PR DESCRIPTION
## Summary
- make the class list items accessible by using a button element

## Testing
- `npm run check` *(fails: svelte-check errors)*
- `go test ./...`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845ab476544832190c3e8b6d52b0608