### PR TITLE
Fix auth token persistence for teacher actions

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,7 +6,8 @@ export async function apiFetch(
   input: RequestInfo,
   init: RequestInit = {}
 ) {
-  const token = localStorage.getItem('jwt')
+  const token =
+    localStorage.getItem('jwt') || get(auth)?.token || undefined
   const headers = new Headers(init.headers)
   if (token) {
     headers.set('Authorization', `Bearer ${token}`)

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -16,12 +16,14 @@ function createAuth() {
     login(token: string, id: number, role: string) {
       const user = { token, id, role }
       localStorage.setItem('user', JSON.stringify(user))
+      localStorage.setItem('jwt', token)   // ensure apiFetch can send it
       set(user)
     },
 
     /** Log out everywhere */
     logout() {
       localStorage.removeItem('user')
+      localStorage.removeItem('jwt')
       set(null)
     },
 


### PR DESCRIPTION
## Summary
- persist JWT token in auth store so it is always available to apiFetch
- allow apiFetch to fall back to the auth store if `localStorage` is missing

## Testing
- `go test ./...`
- `npm run check` *(fails: svelte-check not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c5c2561c83219717fe80b49c38ff