### PR TITLE
Add submission failure reason and detail view

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -270,6 +270,26 @@ func createSubmission(c *gin.Context) {
 	c.JSON(http.StatusCreated, sub)
 }
 
+// getSubmission: GET /api/submissions/:id
+func getSubmission(c *gin.Context) {
+	sid, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	sub, err := GetSubmission(sid)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		return
+	}
+	if c.GetString("role") == "student" && c.GetInt("userID") != sub.StudentID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+	results, _ := ListResultsForSubmission(sid)
+	c.JSON(http.StatusOK, gin.H{"submission": sub, "results": results})
+}
+
 // ---- ADMIN adds a teacher ----
 func createTeacher(c *gin.Context) {
 	var req struct {

--- a/backend/main.go
+++ b/backend/main.go
@@ -75,6 +75,7 @@ func main() {
 		api.DELETE("/assignments/:id", RoleGuard("teacher", "admin"), deleteAssignment)
 		api.POST("/assignments/:id/tests", RoleGuard("teacher", "admin"), createTestCase)
 		api.POST("/assignments/:id/submissions", RoleGuard("student"), createSubmission)
+		api.GET("/submissions/:id", RoleGuard("student", "teacher", "admin"), getSubmission)
 		// TEACHER / STUDENT common
 		api.GET("/classes", RoleGuard("teacher", "student"), myClasses)
 		api.POST("/classes/:id/students", RoleGuard("teacher", "admin"), addStudents)

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,6 +12,7 @@
   import ClassPage  from './routes/ClassDetail.svelte'
   import MyClasses  from './routes/MyClasses.svelte'
   import AssignmentPage from './routes/AssignmentDetail.svelte'
+  import SubmissionPage from './routes/SubmissionDetail.svelte'
 
   const isAuth   = () => !!get(auth)?.token
   const hasRole  = (role: string) => () => get(auth)?.role === role
@@ -29,6 +30,7 @@
     '/my-classes':wrap({ component: MyClasses,    conditions:[isAuth],                     userData:{redirect:'/login'} }),
     '/classes/:id': wrap({ component: ClassPage,  conditions:[isAuth],                     userData:{redirect:'/login'} }),
     '/assignments/:id': wrap({ component: AssignmentPage, conditions:[isAuth], userData:{redirect:'/login'} }),
+    '/submissions/:id': wrap({ component: SubmissionPage, conditions:[isAuth], userData:{redirect:'/login'} }),
 
     '*': Login
   }

--- a/frontend/src/routes/AssignmentDetail.svelte
+++ b/frontend/src/routes/AssignmentDetail.svelte
@@ -74,7 +74,13 @@
     <h3>Your submissions</h3>
     <ul>
       {#each submissions as s}
-        <li>{new Date(s.created_at).toLocaleString()} – {s.status}</li>
+        <li>
+          <a href={`#/submissions/${s.id}`}>{new Date(s.created_at).toLocaleString()}</a>
+          &nbsp;– {s.status}
+          {#if s.failure_reason}
+            &nbsp;({s.failure_reason})
+          {/if}
+        </li>
       {/each}
       {#if !submissions.length}<i>No submissions yet</i>{/if}
     </ul>

--- a/frontend/src/routes/SubmissionDetail.svelte
+++ b/frontend/src/routes/SubmissionDetail.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { apiJSON } from '../lib/api'
+  export let params:{id:string}
+
+  let submission:any=null
+  let results:any[]=[]
+  let err=''
+
+  async function load(){
+    err=''
+    try{
+      const data = await apiJSON(`/api/submissions/${params.id}`)
+      submission = data.submission
+      results = data.results
+    }catch(e:any){ err=e.message }
+  }
+
+  onMount(load)
+</script>
+
+{#if !submission}
+  <p>Loading…</p>
+{:else}
+  <h1>Submission {submission.id}</h1>
+  <p><strong>Status:</strong> {submission.status}</p>
+  <h3>File</h3>
+  <pre>{submission.code_content}</pre>
+  <h3>Results</h3>
+  <ul>
+    {#each results as r}
+      <li>Test {r.test_case_id}: {r.status} ({r.runtime_ms} ms)</li>
+    {/each}
+    {#if !results.length}<i>No results yet</i>{/if}
+  </ul>
+{/if}
+
+{#if err}<p style="color:red">{err}</p>{/if}
+
+<style>
+pre{
+  background:#eee;
+  padding:.5rem;
+  overflow:auto;
+}
+</style>


### PR DESCRIPTION
## Summary
- show failure reason for each submission
- allow viewing single submission with file content and results
- expose submission detail endpoint in backend

## Testing
- `go test ./...`
- `npm run check` *(fails: svelte-check not found or other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684607133fb4832196f438f59014aebf