### PR TITLE
Add time limit to tests

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -216,6 +216,7 @@ func createTestCase(c *gin.Context) {
 	var req struct {
 		Stdin          string `json:"stdin" binding:"required"`
 		ExpectedStdout string `json:"expected_stdout" binding:"required"`
+		TimeLimitMS    int    `json:"time_limit_ms"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -225,6 +226,7 @@ func createTestCase(c *gin.Context) {
 		AssignmentID:   aid,
 		Stdin:          req.Stdin,
 		ExpectedStdout: req.ExpectedStdout,
+		TimeLimitMS:    req.TimeLimitMS,
 	}
 	if err := CreateTestCase(tc); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})

--- a/backend/models.go
+++ b/backend/models.go
@@ -331,11 +331,14 @@ func ListSubmissionsForAssignmentAndStudent(aid, sid int) ([]SubmissionWithReaso
 }
 
 func CreateTestCase(tc *TestCase) error {
+	if tc.TimeLimitMS == 0 {
+		tc.TimeLimitMS = 1000
+	}
 	const q = `
-          INSERT INTO test_cases (assignment_id, stdin, expected_stdout)
-          VALUES ($1,$2,$3)
+          INSERT INTO test_cases (assignment_id, stdin, expected_stdout, time_limit_ms)
+          VALUES ($1,$2,$3,$4)
           RETURNING id, time_limit_ms, memory_limit_kb, created_at, updated_at`
-	return DB.QueryRow(q, tc.AssignmentID, tc.Stdin, tc.ExpectedStdout).
+	return DB.QueryRow(q, tc.AssignmentID, tc.Stdin, tc.ExpectedStdout, tc.TimeLimitMS).
 		Scan(&tc.ID, &tc.TimeLimitMS, &tc.MemoryLimitKB, &tc.CreatedAt, &tc.UpdatedAt)
 }
 

--- a/frontend/src/routes/AssignmentDetail.svelte
+++ b/frontend/src/routes/AssignmentDetail.svelte
@@ -12,7 +12,7 @@
   let tests:any[]=[] // teacher/admin only
   let submissions:any[]=[]
   let err=''
-  let tStdin='', tStdout=''
+  let tStdin='', tStdout='', tLimit=''
   let file:File|null=null
 
   async function load(){
@@ -32,9 +32,9 @@
       await apiFetch(`/api/assignments/${params.id}/tests`,{
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({stdin:tStdin, expected_stdout:tStdout})
+        body:JSON.stringify({stdin:tStdin, expected_stdout:tStdout, time_limit_ms: parseInt(tLimit) || undefined})
       })
-      tStdin=tStdout=''
+      tStdin=tStdout=tLimit=''
       await load()
     }catch(e:any){ err=e.message }
   }
@@ -64,7 +64,7 @@
     <h2>Tests</h2>
     <ul>
       {#each tests ?? [] as t}
-        <li><pre>{t.stdin}</pre>→<pre>{t.expected_stdout}</pre></li>
+        <li><pre>{t.stdin}</pre>→<pre>{t.expected_stdout}</pre> <span>({t.time_limit_ms} ms)</span></li>
       {/each}
       {#if !(tests && tests.length)}<i>No tests</i>{/if}
     </ul>
@@ -88,6 +88,8 @@
     <input placeholder="stdin" bind:value={tStdin}>
     <br>
     <input placeholder="expected stdout" bind:value={tStdout}>
+    <br>
+    <input placeholder="time limit (ms)" bind:value={tLimit}>
     <br>
     <button on:click={addTest}>Add</button>
   {/if}


### PR DESCRIPTION
## Summary
- allow teachers to set `time_limit_ms` when creating tests
- show the limit in the test list

## Testing
- `go test ./...` *(passes)*
- `npm run check` *(fails: svelte-check not found / TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68460be4a56c8321939a8b5dde8bd5be