### PR TITLE
Convert test case timeout to seconds

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -214,9 +214,9 @@ func createTestCase(c *gin.Context) {
 		return
 	}
 	var req struct {
-		Stdin          string `json:"stdin" binding:"required"`
-		ExpectedStdout string `json:"expected_stdout" binding:"required"`
-		TimeLimitMS    int    `json:"time_limit_ms"`
+		Stdin          string  `json:"stdin" binding:"required"`
+		ExpectedStdout string  `json:"expected_stdout" binding:"required"`
+		TimeLimitSec   float64 `json:"time_limit_sec"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -226,7 +226,7 @@ func createTestCase(c *gin.Context) {
 		AssignmentID:   aid,
 		Stdin:          req.Stdin,
 		ExpectedStdout: req.ExpectedStdout,
-		TimeLimitMS:    req.TimeLimitMS,
+		TimeLimitSec:   req.TimeLimitSec,
 	}
 	if err := CreateTestCase(tc); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})

--- a/backend/models.go
+++ b/backend/models.go
@@ -49,7 +49,7 @@ type TestCase struct {
 	AssignmentID   int       `db:"assignment_id" json:"assignment_id"`
 	Stdin          string    `db:"stdin" json:"stdin"`
 	ExpectedStdout string    `db:"expected_stdout" json:"expected_stdout"`
-	TimeLimitMS    int       `db:"time_limit_ms" json:"time_limit_ms"`
+	TimeLimitSec   float64   `db:"time_limit_sec" json:"time_limit_sec"`
 	MemoryLimitKB  int       `db:"memory_limit_kb" json:"memory_limit_kb"`
 	CreatedAt      time.Time `db:"created_at" json:"created_at"`
 	UpdatedAt      time.Time `db:"updated_at" json:"updated_at"`
@@ -331,21 +331,21 @@ func ListSubmissionsForAssignmentAndStudent(aid, sid int) ([]SubmissionWithReaso
 }
 
 func CreateTestCase(tc *TestCase) error {
-	if tc.TimeLimitMS == 0 {
-		tc.TimeLimitMS = 1000
+	if tc.TimeLimitSec == 0 {
+		tc.TimeLimitSec = 1
 	}
 	const q = `
-          INSERT INTO test_cases (assignment_id, stdin, expected_stdout, time_limit_ms)
+          INSERT INTO test_cases (assignment_id, stdin, expected_stdout, time_limit_sec)
           VALUES ($1,$2,$3,$4)
-          RETURNING id, time_limit_ms, memory_limit_kb, created_at, updated_at`
-	return DB.QueryRow(q, tc.AssignmentID, tc.Stdin, tc.ExpectedStdout, tc.TimeLimitMS).
-		Scan(&tc.ID, &tc.TimeLimitMS, &tc.MemoryLimitKB, &tc.CreatedAt, &tc.UpdatedAt)
+          RETURNING id, time_limit_sec, memory_limit_kb, created_at, updated_at`
+	return DB.QueryRow(q, tc.AssignmentID, tc.Stdin, tc.ExpectedStdout, tc.TimeLimitSec).
+		Scan(&tc.ID, &tc.TimeLimitSec, &tc.MemoryLimitKB, &tc.CreatedAt, &tc.UpdatedAt)
 }
 
 func ListTestCases(assignmentID int) ([]TestCase, error) {
 	var list []TestCase
 	err := DB.Select(&list, `
-                SELECT id, assignment_id, stdin, expected_stdout, time_limit_ms, memory_limit_kb, created_at, updated_at
+                SELECT id, assignment_id, stdin, expected_stdout, time_limit_sec, memory_limit_kb, created_at, updated_at
                   FROM test_cases
                  WHERE assignment_id = $1
                  ORDER BY id`, assignmentID)

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS test_cases (
   stdin TEXT NOT NULL,
   expected_stdout TEXT NOT NULL,
   weight NUMERIC NOT NULL DEFAULT 1 CHECK (weight > 0),
-  time_limit_ms INTEGER NOT NULL DEFAULT 1000,
+  time_limit_sec NUMERIC NOT NULL DEFAULT 1.0,
   memory_limit_kb INTEGER NOT NULL DEFAULT 65536,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -71,7 +71,8 @@ func runSubmission(id int) {
 
 	allPass := true
 	for _, tc := range tests {
-		out, err, timedOut, runtime := executePython(codePath, tc.Stdin, time.Duration(tc.TimeLimitMS)*time.Millisecond)
+		timeout := time.Duration(tc.TimeLimitSec * float64(time.Second))
+		out, err, timedOut, runtime := executePython(codePath, tc.Stdin, timeout)
 
 		status := "passed"
 		switch {

--- a/frontend/src/routes/AssignmentDetail.svelte
+++ b/frontend/src/routes/AssignmentDetail.svelte
@@ -39,7 +39,7 @@
       await apiFetch(`/api/assignments/${params.id}/tests`,{
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({stdin:tStdin, expected_stdout:tStdout, time_limit_ms: parseInt(tLimit) || undefined})
+        body:JSON.stringify({stdin:tStdin, expected_stdout:tStdout, time_limit_sec: parseFloat(tLimit) || undefined})
       })
       tStdin=tStdout=tLimit=''
       await load()
@@ -78,7 +78,7 @@
     <h2>Tests</h2>
     <ul>
       {#each tests ?? [] as t, i}
-        <li><pre>Test {i + 1}</pre> <pre>{t.stdin}</pre>→<pre>{t.expected_stdout}</pre> <span>({t.time_limit_ms} ms)</span></li>
+        <li><pre>Test {i + 1}</pre> <pre>{t.stdin}</pre>→<pre>{t.expected_stdout}</pre> <span>({t.time_limit_sec} s)</span></li>
       {/each}
       {#if !(tests && tests.length)}<i>No tests</i>{/if}
     </ul>
@@ -103,7 +103,7 @@
     <br>
     <input placeholder="expected stdout" bind:value={tStdout}>
     <br>
-    <input placeholder="time limit (ms)" bind:value={tLimit}>
+    <input placeholder="time limit (s)" bind:value={tLimit}>
     <br>
     <button on:click={addTest}>Add</button>
   {/if}


### PR DESCRIPTION
## Summary
- use `time_limit_sec` numeric column for test cases
- accept fractional seconds in API and UI
- update worker to use second-based timeout

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684610b1e0d083218f89887f48504232