### PR TITLE
Add Bakalari API login skeleton

### DIFF
--- a/backend/bakalari.go
+++ b/backend/bakalari.go
@@ -55,3 +55,13 @@ type BakalariStudent struct {
 	Name   string `json:"Name"`
 	Abbrev string `json:"Abbrev"`
 }
+
+// ListTeachers should retrieve all teachers. Placeholder until API docs are known.
+func (b *BakalariClient) ListTeachers() ([]BakalariTeacher, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+type BakalariTeacher struct {
+	ID   string `json:"Id"`
+	Name string `json:"Name"`
+}

--- a/backend/bakalari.go
+++ b/backend/bakalari.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// BakalariClient represents a simple client for the Bakalari API.
+type BakalariClient struct {
+	BaseURL     string
+	AccessToken string
+}
+
+// BakalariLogin performs password based authentication against a Bakalari server
+// and returns a client with an access token on success.
+func BakalariLogin(baseURL, username, password string) (*BakalariClient, error) {
+	data := url.Values{}
+	data.Set("client_id", "ANDR")
+	data.Set("grant_type", "password")
+	data.Set("username", username)
+	data.Set("password", password)
+
+	resp, err := http.PostForm(baseURL+"/api/login", data)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("login failed: status %d", resp.StatusCode)
+	}
+	var out struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	if out.AccessToken == "" {
+		return nil, fmt.Errorf("missing token")
+	}
+	return &BakalariClient{BaseURL: baseURL, AccessToken: out.AccessToken}, nil
+}
+
+// ListMyStudents should retrieve all students available to the authenticated
+// teacher account. The specific endpoint varies between installations and is
+// therefore left unimplemented.
+func (b *BakalariClient) ListMyStudents() ([]BakalariStudent, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// BakalariStudent describes a student record returned by Bakalari.
+type BakalariStudent struct {
+	ID     string `json:"Id"`
+	Name   string `json:"Name"`
+	Abbrev string `json:"Abbrev"`
+}

--- a/backend/bakalari_test.go
+++ b/backend/bakalari_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBakalariLogin(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/login" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"abc"}`))
+	}))
+	defer ts.Close()
+
+	client, err := BakalariLogin(ts.URL, "user", "pass")
+	if err != nil {
+		t.Fatalf("login failed: %v", err)
+	}
+	if client.AccessToken != "abc" {
+		t.Fatalf("token mismatch: %s", client.AccessToken)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -89,6 +89,9 @@ func main() {
 		api.GET("/users", RoleGuard("admin"), listUsers)               // new
 		api.PUT("/users/:id/role", RoleGuard("admin"), updateUserRole) // new
 		api.POST("/bakalari/import", RoleGuard("admin"), importStudents)
+		api.POST("/bakalari/import-teachers", RoleGuard("admin"), importTeachers)
+		api.GET("/bakalari/url", RoleGuard("admin"), getBakalariURL)
+		api.PUT("/bakalari/url", RoleGuard("admin"), setBakalariURL)
 
 		// TEACHER only
 		api.POST("/classes", RoleGuard("teacher"), createClass)

--- a/backend/main.go
+++ b/backend/main.go
@@ -50,6 +50,7 @@ func main() {
 	// 3) Public
 	r.POST("/register", Register)
 	r.POST("/login", Login)
+	r.POST("/bakalari-login", bakalariLogin)
 
 	// 4) Protected
 	api := r.Group("/api")
@@ -74,9 +75,9 @@ func main() {
 		api.PUT("/assignments/:id", RoleGuard("teacher", "admin"), updateAssignment)
 		api.DELETE("/assignments/:id", RoleGuard("teacher", "admin"), deleteAssignment)
 		api.PUT("/assignments/:id/publish", RoleGuard("teacher", "admin"), publishAssignment)
-                api.POST("/assignments/:id/tests", RoleGuard("teacher", "admin"), createTestCase)
-                api.DELETE("/tests/:id", RoleGuard("teacher", "admin"), deleteTestCase)
-                api.POST("/assignments/:id/submissions", RoleGuard("student"), createSubmission)
+		api.POST("/assignments/:id/tests", RoleGuard("teacher", "admin"), createTestCase)
+		api.DELETE("/tests/:id", RoleGuard("teacher", "admin"), deleteTestCase)
+		api.POST("/assignments/:id/submissions", RoleGuard("student"), createSubmission)
 		api.GET("/submissions/:id", RoleGuard("student", "teacher", "admin"), getSubmission)
 		// TEACHER / STUDENT common
 		api.GET("/classes", RoleGuard("teacher", "student"), myClasses)
@@ -87,6 +88,7 @@ func main() {
 		api.POST("/teachers", RoleGuard("admin"), createTeacher)
 		api.GET("/users", RoleGuard("admin"), listUsers)               // new
 		api.PUT("/users/:id/role", RoleGuard("admin"), updateUserRole) // new
+		api.POST("/bakalari/import", RoleGuard("admin"), importStudents)
 
 		// TEACHER only
 		api.POST("/classes", RoleGuard("teacher"), createClass)

--- a/backend/models.go
+++ b/backend/models.go
@@ -445,3 +445,20 @@ func ListResultsForSubmission(subID int) ([]Result, error) {
          ORDER BY id`, subID)
 	return list, err
 }
+
+// SetSetting inserts or updates a key/value pair in the settings table.
+func SetSetting(key, value string) error {
+	_, err := DB.Exec(`INSERT INTO settings (key, value) VALUES ($1,$2)
+        ON CONFLICT (key) DO UPDATE SET value=EXCLUDED.value`, key, value)
+	return err
+}
+
+// GetSetting retrieves a configuration value by key.
+func GetSetting(key string) (string, error) {
+	var val string
+	err := DB.Get(&val, `SELECT value FROM settings WHERE key=$1`, key)
+	if err != nil {
+		return "", err
+	}
+	return val, nil
+}

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -79,3 +79,9 @@ CREATE TABLE IF NOT EXISTS class_students (
   student_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   PRIMARY KEY (class_id, student_id)
 );
+
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+

--- a/frontend/src/routes/Admin.svelte
+++ b/frontend/src/routes/Admin.svelte
@@ -3,7 +3,7 @@
   import { apiFetch, apiJSON } from '../lib/api'
 
   // ───────────────────────────────────────── tabs
-  let tab:'teachers'|'users'|'classes' = 'teachers'
+  let tab:'teachers'|'users'|'classes'|'bakalari' = 'teachers'
 
   // ──────────────────────────── 1) add-teacher form
   let email='', password=''
@@ -43,10 +43,63 @@
   let classes:Class[]=[]
   async function loadClasses(){ classes = await apiJSON('/api/classes/all') }
 
+  // ──────────────────────────── 4) Bakalari integration
+  let bakalariURL = ''
+  let bakOk='', bakErr=''
+  let bakUser='', bakPass=''
+  let importMsg='', importErr=''
+  let importTeachMsg='', importTeachErr=''
+
+  async function loadBakalariURL(){
+    try {
+      const r = await apiFetch('/api/bakalari/url')
+      if (r.ok) {
+        bakalariURL = (await r.json()).url
+      }
+    } catch {}
+  }
+
+  async function saveBakalariURL(){
+    bakOk=bakErr=''
+    try{
+      await apiFetch('/api/bakalari/url',{
+        method:'PUT',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({url:bakalariURL})
+      })
+      bakOk='Saved ✔'
+    }catch(e:any){ bakErr=e.message }
+  }
+
+  async function importStudentsBak(){
+    importMsg=importErr=''
+    try{
+      const r = await apiJSON<{imported:number}>('/api/bakalari/import',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({username:bakUser,password:bakPass})
+      })
+      importMsg=`Imported ${r.imported} students`
+    }catch(e:any){ importErr=e.message }
+  }
+
+  async function importTeachersBak(){
+    importTeachMsg=importTeachErr=''
+    try{
+      const r = await apiJSON<{imported:number}>('/api/bakalari/import-teachers',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({username:bakUser,password:bakPass})
+      })
+      importTeachMsg=`Imported ${r.imported} teachers`
+    }catch(e:any){ importTeachErr=e.message }
+  }
+
   // load everything once
   onMount(()=>{
     loadUsers()
     loadClasses()
+    loadBakalariURL()
   })
 </script>
 
@@ -56,6 +109,7 @@
   <button on:click={()=>tab='teachers'} class:active={tab==='teachers'}>Teachers</button>
   <button on:click={()=>tab='users'}    class:active={tab==='users'}   >Users</button>
   <button on:click={()=>tab='classes'}  class:active={tab==='classes'} >Classes</button>
+  <button on:click={()=>tab='bakalari'} class:active={tab==='bakalari'}>Bakalari</button>
 </nav>
 
 {#if tab==='teachers'}
@@ -109,6 +163,28 @@
       {/each}
     </tbody>
   </table>
+{/if}
+
+{#if tab==='bakalari'}
+  <h2>Bakalari settings</h2>
+  <form on:submit|preventDefault={saveBakalariURL}>
+    <input placeholder="Bakalari URL" bind:value={bakalariURL} required />
+    <button>Save</button>
+  </form>
+  {#if bakOk}<p style="color:green">{bakOk}</p>{/if}
+  {#if bakErr}<p style="color:red">{bakErr}</p>{/if}
+
+  <h3>Import users</h3>
+  <input placeholder="Username" bind:value={bakUser} />
+  <input type="password" placeholder="Password" bind:value={bakPass} />
+  <div>
+    <button on:click={importStudentsBak}>Import students</button>
+    <button on:click={importTeachersBak}>Import teachers</button>
+  </div>
+  {#if importMsg}<p style="color:green">{importMsg}</p>{/if}
+  {#if importErr}<p style="color:red">{importErr}</p>{/if}
+  {#if importTeachMsg}<p style="color:green">{importTeachMsg}</p>{/if}
+  {#if importTeachErr}<p style="color:red">{importTeachErr}</p>{/if}
 {/if}
 
 <style>


### PR DESCRIPTION
## Summary
- sketch a Bakalari API client with login function
- stub handlers for Bakalari login and student import
- expose `/bakalari-login` and `/api/bakalari/import` routes
- add a minimal test for `BakalariLogin`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6846c87e156883219b84e0d1b0b5db9a