### PR TITLE
Improve frontend layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Svelte + TS</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+    <title>Code-Grader</title>
   </head>
-  <body>
+  <body class="min-h-screen bg-gray-100 font-sans">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/frontend/src/lib/layouts/AppLayout.svelte
+++ b/frontend/src/lib/layouts/AppLayout.svelte
@@ -9,13 +9,15 @@
   }
 </script>
 
-<nav class="bg-gray-800 text-white px-4 py-2 flex items-center gap-4">
-  <a href="#/dashboard" class="font-bold">Code-Grader</a>
-  <span class="flex-1"></span>
-  {#if $auth}
-    <Button variant="secondary" on:click={() => logout()}>Logout</Button>
-  {/if}
-</nav>
-<div class="p-4 max-w-5xl mx-auto">
-  <slot />
+<div class="min-h-screen flex flex-col bg-gray-50">
+  <nav class="bg-gray-800 text-white px-4 py-3 flex items-center gap-4">
+    <a href="#/dashboard" class="font-bold">Code-Grader</a>
+    <span class="flex-1"></span>
+    {#if $auth}
+      <Button variant="secondary" on:click={() => logout()}>Logout</Button>
+    {/if}
+  </nav>
+  <main class="flex-1 p-4 max-w-5xl w-full mx-auto">
+    <slot />
+  </main>
 </div>

--- a/frontend/src/lib/ui/Input.svelte
+++ b/frontend/src/lib/ui/Input.svelte
@@ -1,0 +1,15 @@
+<script lang="ts" module>
+import { tv } from 'tailwind-variants';
+export const inputVariants = tv({
+  base: 'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
+});
+</script>
+
+<script lang="ts">
+import { cn } from '../utils';
+import type { HTMLInputAttributes } from 'svelte/elements';
+let { ref = $bindable(null), class: className, ...restProps }: HTMLInputAttributes & { ref?: HTMLInputElement | null } = $props();
+const mergedProps = $derived({ ...restProps, class: cn(inputVariants(), className) });
+</script>
+
+<input {...mergedProps} bind:this={ref} />

--- a/frontend/src/routes/Login.svelte
+++ b/frontend/src/routes/Login.svelte
@@ -2,6 +2,8 @@
     import { auth } from '../lib/auth'
     import { apiFetch } from '../lib/api'
     import { push } from 'svelte-spa-router'
+    import Button from '../lib/ui/Button.svelte'
+    import Input  from '../lib/ui/Input.svelte'
     let email = ''
     let password = ''
     let bkUser = ''
@@ -63,27 +65,31 @@
     }
   </script>
   
-  <h1>Log In</h1>
-  <div>
-    <button on:click={() => mode = 'local'} disabled={mode==='local'}>Local</button>
-    <button on:click={() => mode = 'bakalari'} disabled={mode==='bakalari'}>Bakalari</button>
+  <div class="flex min-h-[calc(100vh-4rem)] items-center justify-center">
+    <div class="w-full max-w-md space-y-6 rounded-lg bg-white p-6 shadow">
+      <h1 class="text-center text-2xl font-bold">Log In</h1>
+      <div class="flex justify-center gap-2">
+        <Button on:click={() => mode = 'local'} variant={mode==='local' ? 'default' : 'outline'}>Local</Button>
+        <Button on:click={() => mode = 'bakalari'} variant={mode==='bakalari' ? 'default' : 'outline'}>Bakalari</Button>
+      </div>
+      {#if mode === 'local'}
+        <form on:submit|preventDefault={submit} class="space-y-4">
+          <Input type="email" bind:value={email} placeholder="Email" required />
+          <Input type="password" bind:value={password} placeholder="Password" required />
+          <Button type="submit" class="w-full">Log In</Button>
+        </form>
+      {:else}
+        <form on:submit|preventDefault={submitBk} class="space-y-4">
+          <Input bind:value={bkUser} placeholder="Username" required />
+          <Input type="password" bind:value={bkPass} placeholder="Password" required />
+          <Button type="submit" class="w-full">Log In</Button>
+        </form>
+      {/if}
+      {#if error}
+        <p class="text-center text-red-600">{error}</p>
+      {/if}
+      <p class="text-center text-sm">
+        Don’t have an account? <a href="#/register" class="underline">Register here</a>
+      </p>
+    </div>
   </div>
-  {#if mode === 'local'}
-    <form on:submit|preventDefault={submit}>
-      <input type="email" bind:value={email} placeholder="Email" required />
-      <input type="password" bind:value={password} placeholder="Password" required />
-      <button type="submit">Log In</button>
-    </form>
-  {:else}
-    <form on:submit|preventDefault={submitBk}>
-      <input bind:value={bkUser} placeholder="Username" required />
-      <input type="password" bind:value={bkPass} placeholder="Password" required />
-      <button type="submit">Log In</button>
-    </form>
-  {/if}
-  {#if error}
-    <p style="color: red">{error}</p>
-  {/if}
-  <p>
-    Don’t have an account? <a href="#/register">Register here</a>
-  </p>

--- a/frontend/src/routes/Register.svelte
+++ b/frontend/src/routes/Register.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
     import { push } from 'svelte-spa-router'
+    import Button from '../lib/ui/Button.svelte'
+    import Input  from '../lib/ui/Input.svelte'
     let email = ''
     let password = ''
     let error = ''
@@ -19,16 +21,20 @@
     }
   </script>
   
-  <h1>Register</h1>
-  <form on:submit|preventDefault={submit}>
-    <input type="email" bind:value={email} placeholder="Email" required />
-    <input type="password" bind:value={password} placeholder="Password" required />
-    <button type="submit">Register</button>
-  </form>
-  {#if error}
-    <p style="color: red">{error}</p>
-  {/if}
-  <p>
-    Already have an account? <a href="#/login">Log in</a>
-  </p>
+  <div class="flex min-h-[calc(100vh-4rem)] items-center justify-center">
+    <div class="w-full max-w-md space-y-6 rounded-lg bg-white p-6 shadow">
+      <h1 class="text-center text-2xl font-bold">Register</h1>
+      <form on:submit|preventDefault={submit} class="space-y-4">
+        <Input type="email" bind:value={email} placeholder="Email" required />
+        <Input type="password" bind:value={password} placeholder="Password" required />
+        <Button type="submit" class="w-full">Register</Button>
+      </form>
+      {#if error}
+        <p class="text-center text-red-600">{error}</p>
+      {/if}
+      <p class="text-center text-sm">
+        Already have an account? <a href="#/login" class="underline">Log in</a>
+      </p>
+    </div>
+  </div>
   

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -4,7 +4,11 @@ module.exports = {
     './src/**/*.{svelte,js,ts}'
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
   },
   plugins: [require('@tailwindcss/typography')],
 }


### PR DESCRIPTION
## Summary
- modernize site styles with new `Input` component
- update login/register pages to use nicer layout
- tweak main navigation layout
- use Inter font via Tailwind config

## Testing
- `npm run check` *(fails: svelte-check found errors)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68486e87b3508321a45f15aefd8bc3f5