### PR TITLE
Implement secure hashing and cookie-based sessions

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -28,10 +28,11 @@ func ensureAdmin() {
 		log.Fatalf("admin check failed: %v", err)
 	}
 	if !exists {
-		hash, _ := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+		hashed := clientHash(password)
+		hash, _ := bcrypt.GenerateFromPassword([]byte(hashed), bcrypt.DefaultCost)
 		if _, err := DB.Exec(`
-		    INSERT INTO users (email,password_hash,role)
-		    VALUES ($1,$2,'admin')`, email, hash); err != nil {
+                    INSERT INTO users (email,password_hash,role)
+                    VALUES ($1,$2,'admin')`, email, hash); err != nil {
 			log.Fatalf("could not insert admin: %v", err)
 		}
 		log.Printf("👑  Admin seeded → %s / %s", email, password)
@@ -52,6 +53,7 @@ func main() {
 	r.POST("/api/register", Register)
 	r.POST("/api/login", Login)
 	r.POST("/api/login-bakalari", LoginBakalari)
+	r.POST("/api/refresh", Refresh)
 
 	// 4) Protected
 	api := r.Group("/api")

--- a/backend/middleware.go
+++ b/backend/middleware.go
@@ -10,12 +10,16 @@ import (
 
 func JWTAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		var tokenStr string
 		auth := c.GetHeader("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") {
+		if strings.HasPrefix(auth, "Bearer ") {
+			tokenStr = strings.TrimPrefix(auth, "Bearer ")
+		} else if cookie, err := c.Cookie("access_token"); err == nil {
+			tokenStr = cookie
+		} else {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing token"})
 			return
 		}
-		tokenStr := strings.TrimPrefix(auth, "Bearer ")
 		token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
 			return jwtSecret, nil
 		})

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,18 +1,12 @@
 // RequestInit and RequestInfo are provided by the DOM lib
-import { get } from 'svelte/store'
-import { auth } from './auth'
-
 export async function apiFetch(
   input: RequestInfo,
   init: RequestInit = {}
 ) {
-  const token =
-    localStorage.getItem('jwt') || get(auth)?.token || undefined
-  const headers = new Headers(init.headers)
-  if (token) {
-    headers.set('Authorization', `Bearer ${token}`)
-  }
-  const res = await fetch(input, { ...init, headers })
+  const res = await fetch(input, {
+    ...init,
+    credentials: 'include'
+  })
   return res
 }
 // simple wrapper so we write one line instead of four every time

--- a/frontend/src/lib/hash.ts
+++ b/frontend/src/lib/hash.ts
@@ -1,0 +1,7 @@
+export async function sha256(text: string): Promise<string> {
+  const data = new TextEncoder().encode(text);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hash))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { apiFetch, apiJSON } from '$lib/api'
+  import { sha256 } from '$lib/hash'
 
   // ───────────────────────────────────────── tabs
   let tab:'teachers'|'users'|'classes' = 'teachers'
@@ -14,7 +15,7 @@
     const r = await apiFetch('/api/teachers', {
       method:'POST',
       headers:{'Content-Type':'application/json'},
-      body:JSON.stringify({email,password})
+      body:JSON.stringify({email,password:await sha256(password)})
     })
     if (r.status === 201) { ok='Teacher created ✔'; email=password='' }
     else                  { err=(await r.json()).error }

--- a/frontend/src/routes/register/+page.svelte
+++ b/frontend/src/routes/register/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation'
+    import { sha256 } from '$lib/hash'
     let email = ''
     let password = ''
     let error = ''
@@ -9,7 +10,7 @@
       const res = await fetch('/api/register', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ email, password })
+        body: JSON.stringify({ email, password: await sha256(password) })
       })
       if (res.status === 201) {
         goto('/login')


### PR DESCRIPTION
## Summary
- hash passwords client-side with SHA-256 before submission
- maintain password hashing on server and seed admin with hashed password
- generate short-lived access tokens and long-lived refresh tokens
- store tokens in secure HttpOnly cookies and refresh them via new `/api/refresh`
- read tokens from cookies in middleware
- update Svelte frontend to use cookie auth and hashed passwords

## Testing
- `npm run check`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685ee79e080c83218f0a6355d7f6bb33