### PR TITLE
Improve dashboard design

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1395,6 +1395,7 @@
 			"version": "5.0.43",
 			"resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.43.tgz",
 			"integrity": "sha512-2pshHJ73vetSpsbAyaOncGnNYL0mwvgseS1EWy1I9Qpw8D11OuBoDNIWrPIME4UFcq2xuff3A9x+eXbuFR9fUQ==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/saadeghi/daisyui?sponsor=1"

--- a/frontend/src/routes/+page.ts
+++ b/frontend/src/routes/+page.ts
@@ -1,6 +1,10 @@
 import type { PageLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
 
-export const load: PageLoad = async () => {
+export const load: PageLoad = async ({ fetch }) => {
+  const r = await fetch('/api/me');
+  if (r.ok) {
+    throw redirect(307, '/dashboard');
+  }
   throw redirect(307, '/login');
 };

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -1,37 +1,128 @@
 <script lang="ts">
-    import { auth } from '$lib/auth'
-    import { apiFetch } from '$lib/api'
-    import { onMount } from 'svelte'
-    import { goto } from '$app/navigation'
-  
-  
-    let me = { id: 0, role: '' }
-    let msg = ''
-  
-    onMount(async () => {
-      // fetch /api/me again in case we need fresh data
-      const r1 = await apiFetch('/api/me')
-      if (r1.ok) me = await r1.json()
-  
-      // fetch ping
-      const r2 = await apiFetch('/api/ping')
-      if (r2.ok) {
-        const j = await r2.json()
-        msg = j.msg
+  import { onMount } from 'svelte';
+  import { apiJSON } from '$lib/api';
+
+  let role = '';
+  let classes:any[] = [];
+  let submissions:any[] = [];
+  let upcoming:any[] = [];
+  let loading = true;
+  let err = '';
+
+  function percent(done:number,total:number){
+    return total ? Math.round((done/total)*100) : 0;
+  }
+
+  onMount(async () => {
+    try {
+      const me = await apiJSON('/api/me');
+      role = me.role;
+      classes = await apiJSON('/api/classes');
+
+      if (role === 'student') {
+        submissions = await apiJSON('/api/my-submissions');
       }
-    })
-  
-    function logout() {
-      auth.logout()
-      goto('/login')
+
+      for (const c of classes) {
+        const detail = await apiJSON(`/api/classes/${c.id}`);
+        c.assignments = detail.assignments;
+        c.students = detail.students;
+        c.pointsTotal = c.assignments.reduce((s:any,a:any)=>s+a.max_points,0);
+        if (role === 'student') {
+          c.completed = c.assignments.filter((a:any)=>
+            submissions.find((s:any)=>s.assignment_id===a.id && s.status==='completed')
+          ).length;
+          c.pointsEarned = c.assignments.filter((a:any)=>
+            submissions.find((s:any)=>s.assignment_id===a.id && s.status==='completed')
+          ).reduce((s:any,a:any)=>s+a.max_points,0);
+        } else if (role === 'teacher') {
+          c.progress = [];
+          for (const a of c.assignments) {
+            const data = await apiJSON(`/api/assignments/${a.id}`);
+            const done = new Set(data.submissions.filter((s:any)=>s.status==='completed').map((s:any)=>s.student_id)).size;
+            c.progress.push({ id:a.id, title:a.title, done });
+          }
+        }
+      }
+
+      if (role === 'student') {
+        const now = new Date();
+        const soon = new Date();
+        soon.setDate(soon.getDate()+7);
+        upcoming = classes.flatMap(c=>c.assignments.map(a=>({class:c.name,...a})))
+          .filter(a=>new Date(a.deadline)>now && new Date(a.deadline)<=soon)
+          .sort((a,b)=>new Date(a.deadline).getTime()-new Date(b.deadline).getTime());
+      }
+    } catch(e:any){
+      err = e.message;
     }
+    loading = false;
+  });
+</script>
 
-  </script>
-  
-  <h1>Dashboard</h1>
-  <p><strong>Your ID:</strong> {me.id}</p>
-  <p><strong>Your role:</strong> {me.role}</p>
-  <p><strong>Ping says:</strong> {msg}</p>
-  <button on:click={logout}>Log out</button>
+{#if loading}
+  <div class="flex justify-center mt-8"><span class="loading loading-dots loading-lg"></span></div>
+{:else}
+  <h1 class="text-2xl font-bold mb-6">Dashboard</h1>
 
-  
+  {#if role === 'student'}
+    <div class="grid gap-6 md:grid-cols-2">
+      {#each classes as c}
+        <div class="card bg-base-100 shadow">
+          <div class="card-body">
+            <h2 class="card-title">{c.name}</h2>
+            <div class="stats stats-vertical lg:stats-horizontal mt-3">
+              <div class="stat">
+                <div class="stat-title">Progress</div>
+                <div class="stat-value">{percent(c.completed, c.assignments.length)}%</div>
+                <div class="stat-desc">{c.completed}/{c.assignments.length} assignments</div>
+              </div>
+              <div class="stat">
+                <div class="stat-title">Points</div>
+                <div class="stat-value">{c.pointsEarned}/{c.pointsTotal}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <h2 class="text-xl font-bold mt-8 mb-4">Upcoming deadlines</h2>
+    <ul class="space-y-2">
+      {#each upcoming as a}
+        <li class="flex justify-between items-center p-3 bg-base-100 rounded shadow">
+          <span>{a.title} <span class="text-sm text-base-content/60">({a.class})</span></span>
+          <span class="badge badge-info">{new Date(a.deadline).toLocaleString()}</span>
+        </li>
+      {/each}
+      {#if !upcoming.length}
+        <li><i>No upcoming deadlines</i></li>
+      {/if}
+    </ul>
+  {:else if role === 'teacher'}
+    <div class="grid gap-6 md:grid-cols-2">
+      {#each classes as c}
+        <div class="card bg-base-100 shadow">
+          <div class="card-body">
+            <h2 class="card-title">{c.name}</h2>
+            <p class="text-sm mb-2">{c.students.length} students</p>
+            <ul class="space-y-2">
+              {#each c.assignments as a}
+                <li class="flex items-center justify-between">
+                  <span>{a.title}</span>
+                  <progress class="progress progress-primary w-24" value={c.progress.find((x:any)=>x.id===a.id)?.done || 0} max={c.students.length}></progress>
+                  <span class="text-sm">{c.progress.find((x:any)=>x.id===a.id)?.done || 0}/{c.students.length}</span>
+                </li>
+              {/each}
+              {#if !c.assignments.length}<li><i>No assignments</i></li>{/if}
+            </ul>
+          </div>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  {#if err}
+    <p class="text-error mt-4">{err}</p>
+  {/if}
+{/if}

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -25,8 +25,8 @@
 
       for (const c of classes) {
         const detail = await apiJSON(`/api/classes/${c.id}`);
-        c.assignments = detail.assignments;
-        c.students = detail.students;
+        c.assignments = detail.assignments ?? [];
+        c.students = detail.students ?? [];
         c.pointsTotal = c.assignments.reduce((s:any,a:any)=>s+a.max_points,0);
         if (role === 'student') {
           c.completed = c.assignments.filter((a:any)=>
@@ -39,7 +39,8 @@
           c.progress = [];
           for (const a of c.assignments) {
             const data = await apiJSON(`/api/assignments/${a.id}`);
-            const done = new Set(data.submissions.filter((s:any)=>s.status==='completed').map((s:any)=>s.student_id)).size;
+            const subs = Array.isArray(data.submissions) ? data.submissions : [];
+            const done = new Set(subs.filter((s:any)=>s.status==='completed').map((s:any)=>s.student_id)).size;
             c.progress.push({ id:a.id, title:a.title, done });
           }
         }
@@ -49,7 +50,7 @@
         const now = new Date();
         const soon = new Date();
         soon.setDate(soon.getDate()+7);
-        upcoming = classes.flatMap(c=>c.assignments.map(a=>({class:c.name,...a})))
+        upcoming = classes.flatMap(c=>(c.assignments ?? []).map(a=>({class:c.name,...a})))
           .filter(a=>new Date(a.deadline)>now && new Date(a.deadline)<=soon)
           .sort((a,b)=>new Date(a.deadline).getTime()-new Date(b.deadline).getTime());
       }
@@ -68,7 +69,7 @@
   {#if role === 'student'}
     <div class="grid gap-6 md:grid-cols-2">
       {#each classes as c}
-        <div class="card bg-base-100 shadow">
+        <a href={`/classes/${c.id}`} class="card bg-base-100 shadow hover:shadow-lg block">
           <div class="card-body">
             <h2 class="card-title">{c.name}</h2>
             <div class="stats stats-vertical lg:stats-horizontal mt-3">
@@ -83,7 +84,7 @@
               </div>
             </div>
           </div>
-        </div>
+        </a>
       {/each}
     </div>
 
@@ -102,7 +103,7 @@
   {:else if role === 'teacher'}
     <div class="grid gap-6 md:grid-cols-2">
       {#each classes as c}
-        <div class="card bg-base-100 shadow">
+        <a href={`/classes/${c.id}`} class="card bg-base-100 shadow hover:shadow-lg block">
           <div class="card-body">
             <h2 class="card-title">{c.name}</h2>
             <p class="text-sm mb-2">{c.students.length} students</p>
@@ -117,7 +118,7 @@
               {#if !c.assignments.length}<li><i>No assignments</i></li>{/if}
             </ul>
           </div>
-        </div>
+        </a>
       {/each}
     </div>
   {/if}

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -32,9 +32,8 @@
 
       // 3. Store & smart-redirect
       auth.login(me.id, me.role)
-      if      (me.role === 'admin')   goto('/admin')
-      else if (me.role === 'teacher') goto('/classes')
-      else                            goto('/my-classes')
+      if (me.role === 'admin') goto('/admin')
+      else goto('/dashboard')
     }
     async function submitBk() {
       error = ''
@@ -54,9 +53,8 @@
       }
       const me = await meRes.json()
       auth.login(me.id, me.role)
-      if      (me.role === 'admin')   goto('/admin')
-      else if (me.role === 'teacher') goto('/my-classes')
-      else                            goto('/my-classes')
+      if (me.role === 'admin') goto('/admin')
+      else goto('/dashboard')
     }
   </script>
   


### PR DESCRIPTION
## Summary
- redirect logged-in users to the new dashboard
- update login redirects to go to `/dashboard`
- implement a proper dashboard displaying class progress
- build frontend assets

## Testing
- `go test ./...`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685eec9f23648321aed3b0c16ba5e7f0