### PR TITLE
Fix navbar auth state

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { auth } from '$lib/auth';
-  import { get } from 'svelte/store';
   import { goto } from '$app/navigation';
   import { onMount } from 'svelte';
   import '../app.css';
@@ -10,7 +9,7 @@
     goto('/login');
   }
 
-  $: user = get(auth);
+  $: user = $auth;
 
   onMount(() => {
     auth.init();


### PR DESCRIPTION
## Summary
- make auth store reactive in root layout so Login/Register only show when logged out

## Testing
- `go test ./...`
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efc22911883218c8a7fa3cff0ffa8