### PR TITLE
Add logout endpoint and clear cookies

### DIFF
--- a/backend/auth.go
+++ b/backend/auth.go
@@ -90,6 +90,28 @@ func setAuthCookies(c *gin.Context, access, refresh string) {
 	})
 }
 
+func clearAuthCookies(c *gin.Context) {
+	secure := c.Request.TLS != nil
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     "access_token",
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   -1,
+	})
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     "refresh_token",
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   -1,
+	})
+}
+
 type registerReq struct {
 	Email    string `json:"email" binding:"required,email"`
 	Password string `json:"password" binding:"required,min=6"`
@@ -303,5 +325,10 @@ func Refresh(c *gin.Context) {
 		return
 	}
 	setAuthCookies(c, access, refresh)
+	c.Status(http.StatusNoContent)
+}
+
+func Logout(c *gin.Context) {
+	clearAuthCookies(c)
 	c.Status(http.StatusNoContent)
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -54,6 +54,7 @@ func main() {
 	r.POST("/api/login", Login)
 	r.POST("/api/login-bakalari", LoginBakalari)
 	r.POST("/api/refresh", Refresh)
+	r.POST("/api/logout", Logout)
 
 	// 4) Protected
 	api := r.Group("/api")

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -14,7 +14,14 @@ function createAuth() {
   }
 
   /** Log out everywhere */
-  function logout() {
+  async function logout() {
+    if (browser) {
+      try {
+        await apiFetch('/api/logout', { method: 'POST' });
+      } catch {
+        // ignore errors
+      }
+    }
     set(null);
   }
 

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -50,7 +50,7 @@
         const now = new Date();
         const soon = new Date();
         soon.setDate(soon.getDate()+7);
-        upcoming = classes.flatMap(c=>(c.assignments ?? []).map(a=>({class:c.name,...a})))
+        upcoming = classes.flatMap(c => (c.assignments ?? []).map((a: any) => ({ class: c.name, ...a })))
           .filter(a=>new Date(a.deadline)>now && new Date(a.deadline)<=soon)
           .sort((a,b)=>new Date(a.deadline).getTime()-new Date(b.deadline).getTime());
       }


### PR DESCRIPTION
## Summary
- add `clearAuthCookies` helper and `Logout` handler in Go backend
- expose `/api/logout` route
- call `/api/logout` from frontend auth store
- fix type error in dashboard page

## Testing
- `go test ./...` in `backend`
- `npm --prefix frontend run check`

------
https://chatgpt.com/codex/tasks/task_e_685f050ba8c88321879477a9cee52378