### PR TITLE
Add submission overview table

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -26,6 +26,7 @@
           <a href="/classes" class="btn btn-ghost">Classes</a>
         {:else if user?.role === 'student'}
           <a href="/classes" class="btn btn-ghost">My Classes</a>
+          <a href="/submissions" class="btn btn-ghost">Submissions</a>
         {/if}
       </div>
       <div class="flex-none gap-2">

--- a/frontend/src/routes/assignments/[id]/+page.svelte
+++ b/frontend/src/routes/assignments/[id]/+page.svelte
@@ -227,15 +227,25 @@ $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100)
 
   {#if role==='student'}
     <h3>Your submissions</h3>
-    <ul>
-      {#each submissions as s}
-        <li>
-          <a href={`/submissions/${s.id}`}>{new Date(s.created_at).toLocaleString()}</a>
-          &nbsp;– {s.status}
-        </li>
-      {/each}
-      {#if !submissions.length}<i>No submissions yet</i>{/if}
-    </ul>
+    <div class="overflow-x-auto">
+      <table class="table table-zebra">
+        <thead>
+          <tr><th>Date</th><th>Status</th><th></th></tr>
+        </thead>
+        <tbody>
+          {#each submissions as s}
+            <tr>
+              <td>{new Date(s.created_at).toLocaleString()}</td>
+              <td><span class={`badge ${statusColor(s.status)}`}>{s.status}</span></td>
+              <td><a href={`/submissions/${s.id}`} class="btn btn-sm btn-outline">view</a></td>
+            </tr>
+          {/each}
+          {#if !submissions.length}
+            <tr><td colspan="3"><i>No submissions yet</i></td></tr>
+          {/if}
+        </tbody>
+      </table>
+    </div>
   {/if}
 
   {#if role==='teacher' || role==='admin'}

--- a/frontend/src/routes/submissions/+page.svelte
+++ b/frontend/src/routes/submissions/+page.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { apiJSON } from '$lib/api';
+
+  interface Submission {
+    id: number;
+    assignment_id: number;
+    status: string;
+    created_at: string;
+    results?: any[];
+  }
+
+  let subs: Submission[] = [];
+  let titles: Record<number,string> = {};
+  let loading = true;
+  let err = '';
+
+  function resultColor(s: string){
+    if(s === 'passed') return 'badge-success';
+    if(s === 'wrong_output') return 'badge-error';
+    if(s === 'time_limit_exceeded' || s==='memory_limit_exceeded') return 'badge-warning';
+    return '';
+  }
+
+  function statusColor(s: string){
+    if(s === 'completed') return 'badge-success';
+    if(s === 'running') return 'badge-info';
+    if(s === 'failed') return 'badge-error';
+    return '';
+  }
+
+  async function load(){
+    err='';
+    try{
+      subs = await apiJSON('/api/my-submissions');
+      const aids = Array.from(new Set(subs.map(s=>s.assignment_id)));
+      for(const id of aids){
+        const data = await apiJSON(`/api/assignments/${id}`);
+        titles[id] = data.assignment.title;
+      }
+      for(const s of subs){
+        const data = await apiJSON(`/api/submissions/${s.id}`);
+        s.results = data.results;
+      }
+    }catch(e:any){ err = e.message }
+    loading = false;
+  }
+
+  onMount(load);
+</script>
+
+{#if loading}
+  <div class="flex justify-center mt-8"><span class="loading loading-dots loading-lg"></span></div>
+{:else}
+  <h1 class="text-2xl font-bold mb-6">My Submissions</h1>
+  <div class="overflow-x-auto">
+    <table class="table table-zebra">
+      <thead>
+        <tr><th>Date</th><th>Assignment</th><th>Status</th><th>Tests</th></tr>
+      </thead>
+      <tbody>
+        {#each subs as s}
+          <tr>
+            <td>{new Date(s.created_at).toLocaleString()}</td>
+            <td>{titles[s.assignment_id] ?? s.assignment_id}</td>
+            <td><span class={`badge ${statusColor(s.status)}`}>{s.status}</span></td>
+            <td>
+              <div class="flex flex-wrap gap-1">
+                {#each s.results ?? [] as r, i}
+                  <span class={`badge badge-sm ${resultColor(r.status)} tooltip`} data-tip={`${r.status} ${r.runtime_ms}ms`}>{i+1}</span>
+                {/each}
+                {#if !(s.results && s.results.length)}<i>pending</i>{/if}
+              </div>
+            </td>
+          </tr>
+        {/each}
+        {#if !subs.length}
+          <tr><td colspan="4"><i>No submissions yet</i></td></tr>
+        {/if}
+      </tbody>
+    </table>
+  </div>
+  {#if err}<p class="text-error mt-4">{err}</p>{/if}
+{/if}

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -22,6 +22,9 @@ $: id = $page.params.id
     if(s==='completed') return 'badge-success'
     if(s==='running') return 'badge-info'
     if(s==='failed') return 'badge-error'
+    if(s==='passed') return 'badge-success'
+    if(s==='wrong_output') return 'badge-error'
+    if(s==='time_limit_exceeded' || s==='memory_limit_exceeded') return 'badge-warning'
     return ''
   }
 
@@ -47,12 +50,25 @@ $: id = $page.params.id
     <div class="card bg-base-100 shadow">
       <div class="card-body">
         <h3 class="card-title">Results</h3>
-        <ul class="list-disc ml-6">
-          {#each results as r, i}
-            <li>Test {i + 1}: <span class={`badge ${statusColor(r.status)}`}>{r.status}</span> ({r.runtime_ms} ms)</li>
-          {/each}
-          {#if Array.isArray(results) && !results.length}<i>No results yet</i>{/if}
-        </ul>
+        <div class="overflow-x-auto">
+          <table class="table table-zebra">
+            <thead>
+              <tr><th>Test</th><th>Status</th><th>Runtime (ms)</th></tr>
+            </thead>
+            <tbody>
+              {#each results as r, i}
+                <tr>
+                  <td>{i + 1}</td>
+                  <td><span class={`badge ${statusColor(r.status)}`}>{r.status}</span></td>
+                  <td>{r.runtime_ms}</td>
+                </tr>
+              {/each}
+              {#if Array.isArray(results) && !results.length}
+                <tr><td colspan="3"><i>No results yet</i></td></tr>
+              {/if}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add a submissions overview page
- link to it from navbar
- show submissions in table on assignment detail page
- display results in a table on submission detail page

## Testing
- `go test ./...`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_685f066322788321826719bb172a12d9