### PR TITLE
Add Markdown editor for assignments

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -101,18 +101,19 @@ func createAssignment(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Title string `json:"title" binding:"required"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
+        var req struct {
+                Title       string `json:"title" binding:"required"`
+                Description string `json:"description"`
+        }
+        if err := c.ShouldBindJSON(&req); err != nil {
+                c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+                return
+        }
 
 	a := &Assignment{
 		ClassID:       classID,
-		Title:         req.Title,
-		Description:   "",
+                Title:         req.Title,
+                Description:   req.Description,
 		Deadline:      time.Now().Add(24 * time.Hour),
 		MaxPoints:     100,
 		GradingPolicy: "all_or_nothing",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "frontend",
 			"version": "0.0.1",
 			"dependencies": {
+				"@fortawesome/fontawesome-free": "^6.7.2",
 				"@tailwindcss/vite": "^4.1.11",
 				"daisyui": "^5.0.43",
 				"easymde": "^2.20.0",
@@ -470,6 +471,15 @@
 			"integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@fortawesome/fontawesome-free": {
+			"version": "6.7.2",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+			"integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+			"license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/@isaacs/fs-minipass": {
 			"version": "4.0.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,9 @@
 			"dependencies": {
 				"@tailwindcss/vite": "^4.1.11",
 				"daisyui": "^5.0.43",
+				"easymde": "^2.20.0",
 				"jwt-decode": "^4.0.0",
+				"marked": "^16.0.0",
 				"tailwindcss": "^4.1.11"
 			},
 			"devDependencies": {
@@ -1271,6 +1273,15 @@
 				"vite": "^5.2.0 || ^6 || ^7"
 			}
 		},
+		"node_modules/@types/codemirror": {
+			"version": "5.60.16",
+			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.16.tgz",
+			"integrity": "sha512-V/yHdamffSS075jit+fDxaOAmdP2liok8NSNJnAZfDJErzOheuygHZEhAJrfmk5TEyM32MhkZjwo/idX791yxw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/tern": "*"
+			}
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1284,12 +1295,27 @@
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"license": "MIT"
 		},
+		"node_modules/@types/marked": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
+			"integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
+			"license": "MIT"
+		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
 			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/tern": {
+			"version": "0.23.9",
+			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+			"integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "*"
+			}
 		},
 		"node_modules/@yr/monotone-cubic-spline": {
 			"version": "1.0.3",
@@ -1381,6 +1407,21 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/codemirror": {
+			"version": "5.65.19",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.19.tgz",
+			"integrity": "sha512-+aFkvqhaAVr1gferNMuN8vkTSrWIFvzlMV9I2KBLCWS2WpZ2+UAkZjlMZmEuT+gcXTi6RrGQCkWq1/bDtGqhIA==",
+			"license": "MIT"
+		},
+		"node_modules/codemirror-spell-checker": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz",
+			"integrity": "sha512-2Tl6n0v+GJRsC9K3MLCdLaMOmvWL0uukajNJseorZJsslaxZyZMgENocPU8R0DyoTAiKsyqiemSOZo7kjGV0LQ==",
+			"license": "MIT",
+			"dependencies": {
+				"typo-js": "*"
+			}
+		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -1444,6 +1485,31 @@
 			"integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/easymde": {
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/easymde/-/easymde-2.20.0.tgz",
+			"integrity": "sha512-V1Z5f92TfR42Na852OWnIZMbM7zotWQYTddNaLYZFVKj7APBbyZ3FYJ27gBw2grMW3R6Qdv9J8n5Ij7XRSIgXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/codemirror": "^5.60.10",
+				"@types/marked": "^4.0.7",
+				"codemirror": "^5.65.15",
+				"codemirror-spell-checker": "1.1.2",
+				"marked": "^4.1.0"
+			}
+		},
+		"node_modules/easymde/node_modules/marked": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.18.2",
@@ -1954,6 +2020,18 @@
 				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
 		},
+		"node_modules/marked": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-16.0.0.tgz",
+			"integrity": "sha512-MUKMXDjsD/eptB7GPzxo4xcnLS6oo7/RHimUMHEDRhUooPwmN9BEpMl7AEOJv3bmso169wHI2wUF9VQgL7zfmA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
 		"node_modules/mini-svg-data-uri": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
@@ -2389,6 +2467,12 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/typo-js": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.2.5.tgz",
+			"integrity": "sha512-F45vFWdGX8xahIk/sOp79z2NJs8ETMYsmMChm9D5Hlx3+9j7VnCyQyvij5MOCrNY3NNe8noSyokRjQRfq+Bc7A==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/uuid": {
 			"version": "11.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,8 @@
 		"daisyui": "^5.0.43",
 		"easymde": "^2.20.0",
 		"jwt-decode": "^4.0.0",
-		"marked": "^16.0.0",
-		"tailwindcss": "^4.1.11"
-	}
+                "marked": "^16.0.0",
+                "@fortawesome/fontawesome-free": "^6.7.2",
+                "tailwindcss": "^4.1.11"
+        }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,10 +15,10 @@
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
+		"daisyui": "^5.0.0",
 		"flowbite": "^3.1.2",
 		"flowbite-svelte": "^1.8.2",
-                "flowbite-svelte-icons": "^2.2.1",
-                "daisyui": "^5.0.0",
+		"flowbite-svelte-icons": "^2.2.1",
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
 		"typescript": "^5.0.0",
@@ -28,7 +28,9 @@
 	"dependencies": {
 		"@tailwindcss/vite": "^4.1.11",
 		"daisyui": "^5.0.43",
+		"easymde": "^2.20.0",
 		"jwt-decode": "^4.0.0",
+		"marked": "^16.0.0",
 		"tailwindcss": "^4.1.11"
 	}
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,2 +1,35 @@
 @import "tailwindcss";
 @plugin "daisyui";
+.markdown, .editor-preview, .editor-preview-side {
+  line-height: 1.5;
+}
+.markdown h1, .editor-preview h1, .editor-preview-side h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0.5rem 0;
+}
+.markdown h2, .editor-preview h2, .editor-preview-side h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0.5rem 0;
+}
+.markdown ul, .editor-preview ul, .editor-preview-side ul {
+  list-style: disc;
+  margin-left: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+.markdown ol, .editor-preview ol, .editor-preview-side ol {
+  list-style: decimal;
+  margin-left: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+.markdown pre, .editor-preview pre, .editor-preview-side pre {
+  background: #f5f5f5;
+  padding: 0.5rem;
+  overflow-x: auto;
+}
+.markdown code, .editor-preview code, .editor-preview-side code {
+  background: #f5f5f5;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+}

--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { createEventDispatcher } from 'svelte';
+  import EasyMDE from 'easymde';
+  import 'easymde/dist/easymde.min.css';
+
+  export let value = '';
+  export let placeholder = '';
+
+  let textarea: HTMLTextAreaElement;
+  let editor: EasyMDE;
+  const dispatch = createEventDispatcher();
+
+  onMount(() => {
+    editor = new EasyMDE({
+      element: textarea,
+      initialValue: value,
+      placeholder,
+      autoDownloadFontAwesome: false,
+      spellChecker: false
+    });
+    editor.codemirror.on('change', () => {
+      value = editor.value();
+      dispatch('input', value);
+    });
+  });
+
+  onDestroy(() => {
+    editor?.toTextArea();
+  });
+
+  $: if (editor && value !== editor.value()) {
+    editor.value(value);
+  }
+</script>
+
+<textarea bind:this={textarea}></textarea>

--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -1,18 +1,21 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { createEventDispatcher } from 'svelte';
-  import EasyMDE from 'easymde';
-  import 'easymde/dist/easymde.min.css';
   import '@fortawesome/fontawesome-free/css/all.min.css';
+
+  let EasyMDE: typeof import('easymde');
 
   export let value = '';
   export let placeholder = '';
 
   let textarea: HTMLTextAreaElement;
-  let editor: EasyMDE;
+  let editor: import('easymde').default | null = null;
   const dispatch = createEventDispatcher();
 
-  onMount(() => {
+  onMount(async () => {
+    const mod = await import('easymde');
+    await import('easymde/dist/easymde.min.css');
+    EasyMDE = mod.default;
     editor = new EasyMDE({
       element: textarea,
       initialValue: value,
@@ -21,13 +24,14 @@
       spellChecker: false
     });
     editor.codemirror.on('change', () => {
-      value = editor.value();
+      value = editor!.value();
       dispatch('input', value);
     });
   });
 
   onDestroy(() => {
     editor?.toTextArea();
+    editor = null;
   });
 
   $: if (editor && value !== editor.value()) {

--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -3,6 +3,7 @@
   import { createEventDispatcher } from 'svelte';
   import EasyMDE from 'easymde';
   import 'easymde/dist/easymde.min.css';
+  import '@fortawesome/fontawesome-free/css/all.min.css';
 
   export let value = '';
   export let placeholder = '';

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -1,1 +1,2 @@
 // place files you want to import through the `$lib` alias in this folder.
+export { default as MarkdownEditor } from './MarkdownEditor.svelte';

--- a/frontend/src/routes/assignments/[id]/+page.svelte
+++ b/frontend/src/routes/assignments/[id]/+page.svelte
@@ -177,7 +177,7 @@ $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100)
             </div>
           {/if}
         </div>
-        <div>{@html marked.parse(assignment.description)}</div>
+        <div class="markdown">{@html marked.parse(assignment.description)}</div>
         <p><strong>Deadline:</strong> {new Date(assignment.deadline).toLocaleString()}</p>
         <p><strong>Max points:</strong> {assignment.max_points}</p>
         <p><strong>Policy:</strong> {assignment.grading_policy}</p>

--- a/frontend/src/routes/assignments/[id]/+page.svelte
+++ b/frontend/src/routes/assignments/[id]/+page.svelte
@@ -3,6 +3,8 @@
   import { get } from 'svelte/store'
   import { auth } from '$lib/auth'
 import { apiFetch, apiJSON } from '$lib/api'
+import { MarkdownEditor } from '$lib'
+import { marked } from 'marked'
 import { goto } from '$app/navigation'
 import { page } from '$app/stores'
 
@@ -149,7 +151,7 @@ $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100)
       <div class="card-body space-y-3">
         <h1 class="card-title">Edit assignment</h1>
         <input class="input input-bordered w-full" bind:value={eTitle} placeholder="Title" required>
-        <textarea class="textarea textarea-bordered w-full" bind:value={eDesc} placeholder="Description" required></textarea>
+        <MarkdownEditor bind:value={eDesc} placeholder="Description" />
         <input type="number" min="1" class="input input-bordered w-full" bind:value={ePoints} placeholder="Max points" required>
         <select class="select select-bordered w-full" bind:value={ePolicy}>
           <option value="all_or_nothing">all_or_nothing</option>
@@ -175,7 +177,7 @@ $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100)
             </div>
           {/if}
         </div>
-        <p>{assignment.description}</p>
+        <div>{@html marked.parse(assignment.description)}</div>
         <p><strong>Deadline:</strong> {new Date(assignment.deadline).toLocaleString()}</p>
         <p><strong>Max points:</strong> {assignment.max_points}</p>
         <p><strong>Policy:</strong> {assignment.grading_policy}</p>

--- a/frontend/src/routes/classes/[id]/+page.svelte
+++ b/frontend/src/routes/classes/[id]/+page.svelte
@@ -190,7 +190,7 @@ import { marked } from 'marked';
                 {/if}
                 <span class={new Date(a.deadline)<new Date() ? 'text-error' : ''}>due {new Date(a.deadline).toLocaleString()}</span>
               </div>
-              <p class="text-sm">{@html marked.parse(a.description)} (max {a.max_points} pts, {a.grading_policy})</p>
+              <p class="text-sm markdown">{@html marked.parse(a.description)} (max {a.max_points} pts, {a.grading_policy})</p>
             </li>
           {/each}
           {#if !assignments.length}<li><i>No assignments yet</i></li>{/if}


### PR DESCRIPTION
## Summary
- create a `MarkdownEditor` component using EasyMDE
- allow teachers to enter assignment descriptions with markdown
- render markdown on assignment pages and lists
- accept description when creating assignments via API
- include `easymde` and `marked` dependencies

## Testing
- `go test ./...`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f0e81d82c8321ab3fb47da4f1a7b8