### PR TITLE
Add link to upcoming deadlines

### DIFF
--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -91,9 +91,14 @@
     <h2 class="text-xl font-bold mt-8 mb-4">Upcoming deadlines</h2>
     <ul class="space-y-2">
       {#each upcoming as a}
-        <li class="flex justify-between items-center p-3 bg-base-100 rounded shadow">
-          <span>{a.title} <span class="text-sm text-base-content/60">({a.class})</span></span>
-          <span class="badge badge-info">{new Date(a.deadline).toLocaleString()}</span>
+        <li>
+          <a
+            href={`/assignments/${a.id}`}
+            class="flex justify-between items-center p-3 bg-base-100 rounded shadow hover:bg-base-200"
+          >
+            <span>{a.title} <span class="text-sm text-base-content/60">({a.class})</span></span>
+            <span class="badge badge-info">{new Date(a.deadline).toLocaleString()}</span>
+          </a>
         </li>
       {/each}
       {#if !upcoming.length}


### PR DESCRIPTION
## Summary
- link items in the "Upcoming deadlines" list to the assignment detail page

## Testing
- `npm run check` *(fails: Namespace 'EasyMDE' has no exported member 'default')*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685f19709a3c8321a72d34ad744fd77f