### PR TITLE
Refine class assignments view

### DIFF
--- a/frontend/src/routes/classes/[id]/+page.svelte
+++ b/frontend/src/routes/classes/[id]/+page.svelte
@@ -13,6 +13,7 @@ import { marked } from 'marked';
   let cls:any = null;
   let students:any[] = [];
   let assignments:any[] = [];
+  let mySubs:any[] = [];
   let allStudents:any[] = [];
   let selectedIDs:number[] = [];
   let search='';
@@ -29,6 +30,13 @@ import { marked } from 'marked';
       cls = data;
       students = data.students;
       assignments = [...(data.assignments ?? [])].sort((a,b)=>new Date(a.deadline).getTime()-new Date(b.deadline).getTime());
+      if (role === 'student') {
+        mySubs = await apiJSON('/api/my-submissions');
+        assignments = assignments.map(a => ({
+          ...a,
+          completed: mySubs.some((s:any)=>s.assignment_id===a.id && s.status==='completed')
+        }));
+      }
       if (role === 'teacher' || role === 'admin') allStudents = await apiJSON('/api/students');
     } catch(e:any){ err=e.message }
   }
@@ -177,20 +185,19 @@ import { marked } from 'marked';
         <h2 class="card-title">Assignments</h2>
         <ul class="space-y-4">
           {#each assignments as a}
-            <li class="border-b pb-2 last:border-none">
-              <div class="flex justify-between items-center">
-                <a href={`/assignments/${a.id}`} class="link link-primary text-lg">{a.title}</a>
-                {#if role === 'teacher' || role === 'admin'}
-                  <button class="btn btn-xs btn-error" on:click={()=>deleteAssignment(a.id)}>Delete</button>
-                {/if}
+            <li class={`card shadow ${a.completed ? 'bg-success/10' : 'bg-base-100'}`}> 
+              <div class="card-body flex-row justify-between items-center py-3">
+                <a href={`/assignments/${a.id}`} class={`link link-primary text-lg ${a.completed ? 'line-through' : ''}`}>{a.title}</a>
+                <div class="flex items-center gap-2">
+                  <span class={`badge ${new Date(a.deadline)<new Date() && !a.completed ? 'badge-error' : 'badge-info'}`}>{new Date(a.deadline).toLocaleString()}</span>
+                  {#if a.completed}
+                    <span class="badge badge-success">done</span>
+                  {/if}
+                  {#if role === 'teacher' || role === 'admin'}
+                    <button class="btn btn-xs btn-error" on:click={()=>deleteAssignment(a.id)}>Delete</button>
+                  {/if}
+                </div>
               </div>
-              <div class="text-sm mb-1">
-                {#if !a.published}
-                  <span class="badge badge-sm mr-2">draft</span>
-                {/if}
-                <span class={new Date(a.deadline)<new Date() ? 'text-error' : ''}>due {new Date(a.deadline).toLocaleString()}</span>
-              </div>
-              <p class="text-sm markdown">{@html marked.parse(a.description)} (max {a.max_points} pts, {a.grading_policy})</p>
             </li>
           {/each}
           {#if !assignments.length}<li><i>No assignments yet</i></li>{/if}

--- a/frontend/src/routes/classes/[id]/+page.svelte
+++ b/frontend/src/routes/classes/[id]/+page.svelte
@@ -22,6 +22,22 @@ import { marked } from 'marked';
   let aTitle='';
   let aDesc='';
   let err='';
+  let now = Date.now();
+
+  onMount(() => {
+    const t = setInterval(() => now = Date.now(), 60000);
+    return () => clearInterval(t);
+  });
+
+  function countdown(deadline: string) {
+    const diff = new Date(deadline).getTime() - now;
+    if (diff <= 0) return 'late';
+    const d = Math.floor(diff / 86400000);
+    if (d >= 1) return `${d}d`;
+    const h = Math.floor(diff / 3600000);
+    const m = Math.floor((diff % 3600000) / 60000);
+    return `${h}h ${m}m`;
+  }
 
   async function load() {
     err='';
@@ -185,19 +201,22 @@ import { marked } from 'marked';
         <h2 class="card-title">Assignments</h2>
         <ul class="space-y-4">
           {#each assignments as a}
-            <li class={`card shadow ${a.completed ? 'bg-success/10' : 'bg-base-100'}`}> 
-              <div class="card-body flex-row justify-between items-center py-3">
-                <a href={`/assignments/${a.id}`} class={`link link-primary text-lg ${a.completed ? 'line-through' : ''}`}>{a.title}</a>
-                <div class="flex items-center gap-2">
-                  <span class={`badge ${new Date(a.deadline)<new Date() && !a.completed ? 'badge-error' : 'badge-info'}`}>{new Date(a.deadline).toLocaleString()}</span>
-                  {#if a.completed}
-                    <span class="badge badge-success">done</span>
-                  {/if}
-                  {#if role === 'teacher' || role === 'admin'}
-                    <button class="btn btn-xs btn-error" on:click={()=>deleteAssignment(a.id)}>Delete</button>
-                  {/if}
+            <li>
+              <a href={`/assignments/${a.id}`} class={`block no-underline text-current card shadow transition hover:-translate-y-1 hover:shadow-lg ${a.completed ? 'bg-success/10' : 'bg-base-100'}`}>
+                <div class="card-body flex-col sm:flex-row justify-between items-start sm:items-center gap-2 py-3">
+                  <span class="text-lg font-semibold text-primary">{a.title}</span>
+                  <div class="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:justify-end w-full sm:w-auto">
+                    <span class={`badge ${new Date(a.deadline)<new Date() && !a.completed ? 'badge-error' : 'badge-info'}`}>{new Date(a.deadline).toLocaleString()}</span>
+                    <span class="text-sm">{countdown(a.deadline)}</span>
+                    {#if a.completed}
+                      <span class="badge badge-success">done</span>
+                    {/if}
+                    {#if role === 'teacher' || role === 'admin'}
+                      <button class="btn btn-xs btn-error" on:click|stopPropagation={()=>deleteAssignment(a.id)}>Delete</button>
+                    {/if}
+                  </div>
                 </div>
-              </div>
+              </a>
             </li>
           {/each}
           {#if !assignments.length}<li><i>No assignments yet</i></li>{/if}


### PR DESCRIPTION
## Summary
- highlight done assignments and hide their description
- show only title and deadline in class view

## Testing
- `npm run check` *(fails: svelte-check found 2 errors and 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685f19f698c08321aac9ab73b6d91023