### PR TITLE
Add code snippet button

### DIFF
--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -3,13 +3,14 @@
   import { createEventDispatcher } from 'svelte';
   import '@fortawesome/fontawesome-free/css/all.min.css';
 
-  let EasyMDE: typeof import('easymde');
+  let EasyMDE: any;
 
   export let value = '';
   export let placeholder = '';
+  export let className: string = '';
 
   let textarea: HTMLTextAreaElement;
-  let editor: import('easymde').default | null = null;
+  let editor: any = null;
   const dispatch = createEventDispatcher();
 
   onMount(async () => {
@@ -21,7 +22,25 @@
       initialValue: value,
       placeholder,
       autoDownloadFontAwesome: false,
-      spellChecker: false
+      spellChecker: false,
+      toolbar: [
+        'bold',
+        'italic',
+        'heading',
+        '|',
+        'code',
+        'unordered-list',
+        'ordered-list',
+        '|',
+        'link',
+        'image',
+        '|',
+        'preview',
+        'side-by-side',
+        'fullscreen',
+        '|',
+        'guide'
+      ]
     });
     editor.codemirror.on('change', () => {
       value = editor!.value();
@@ -39,4 +58,4 @@
   }
 </script>
 
-<textarea bind:this={textarea}></textarea>
+<textarea bind:this={textarea} class={className}></textarea>

--- a/frontend/src/routes/classes/[id]/+page.svelte
+++ b/frontend/src/routes/classes/[id]/+page.svelte
@@ -225,7 +225,7 @@ import { marked } from 'marked';
         {#if role === 'teacher' || role === 'admin'}
           <form class="mt-4" on:submit|preventDefault={createAssignment}>
             <input class="input input-bordered w-full mb-2" placeholder="Title" bind:value={aTitle} required>
-            <MarkdownEditor bind:value={aDesc} placeholder="Description" class="mb-2" />
+            <MarkdownEditor bind:value={aDesc} placeholder="Description" className="mb-2" />
             <button class="btn">Create</button>
           </form>
         {/if}


### PR DESCRIPTION
## Summary
- add a custom toolbar in the Markdown editor
- allow passing className prop to `MarkdownEditor`
- update class creation form to use new prop

## Testing
- `go test ./...`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685f1e2aa2148321aa091a9de6e99e25