### PR TITLE
Show label for unpublished assignments

### DIFF
--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -9,7 +9,7 @@
   export let placeholder = '';
 
   let textarea: HTMLTextAreaElement;
-  let editor: import('easymde').default | null = null;
+  let editor: any = null;
   const dispatch = createEventDispatcher();
 
   onMount(async () => {

--- a/frontend/src/routes/classes/[id]/+page.svelte
+++ b/frontend/src/routes/classes/[id]/+page.svelte
@@ -205,6 +205,9 @@ import { marked } from 'marked';
                   <div class="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:justify-end w-full sm:w-auto">
                     <span class={`badge ${new Date(a.deadline)<new Date() && !a.completed ? 'badge-error' : 'badge-info'}`}>{new Date(a.deadline).toLocaleString()}</span>
                     <span class="text-sm">{countdown(a.deadline)}</span>
+                    {#if !a.published}
+                      <span class="badge badge-warning">unpublished</span>
+                    {/if}
                     {#if a.completed}
                       <span class="badge badge-success">done</span>
                     {/if}


### PR DESCRIPTION
## Summary
- mark unpublished assignments in teacher view
- relax strict type for MarkdownEditor to satisfy svelte check

## Testing
- `go test ./...`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685f1ec8362c8321aa78bfb3baa33099