### PR TITLE
Add image size option to editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ You can copy `backend/.env.example` and adjust it for your environment.
 - Improved UX/UI
 - Time and memory limits per test case
 - Submission history and feedback view
-- Image size controls in the assignment editor
+- Image resizing via drag handles in the assignment editor
 
 ### Phase 3: Language Support and Administration
 - Support for C++, Java, and other languages

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ You can copy `backend/.env.example` and adjust it for your environment.
 - Improved UX/UI
 - Time and memory limits per test case
 - Submission history and feedback view
+- Image size controls in the assignment editor
 
 ### Phase 3: Language Support and Administration
 - Support for C++, Java, and other languages

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -33,3 +33,13 @@
   padding: 0.2rem 0.4rem;
   border-radius: 4px;
 }
+.resizable-wrapper {
+  display: inline-block;
+  resize: both;
+  overflow: auto;
+}
+.resizable-wrapper img {
+  max-width: 100%;
+  height: auto;
+  pointer-events: none;
+}

--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -13,6 +13,18 @@
   let editor: any = null;
   const dispatch = createEventDispatcher();
 
+  function insertImageWithSize(editor: any) {
+    const url = prompt('Enter image URL');
+    if (!url) return;
+    const width = prompt('Width (optional)');
+    const height = prompt('Height (optional)');
+    let attrs = '';
+    if (width) attrs += ` width="${width}"`;
+    if (height) attrs += ` height="${height}"`;
+    const html = `<img src="${url}"${attrs}>`;
+    editor.codemirror.replaceSelection(html);
+  }
+
   onMount(async () => {
     const mod = await import('easymde');
     await import('easymde/dist/easymde.min.css');
@@ -33,7 +45,12 @@
         'ordered-list',
         '|',
         'link',
-        'image',
+        {
+          name: 'image',
+          action: insertImageWithSize,
+          className: 'fa fa-image',
+          title: 'Insert image'
+        },
         '|',
         'preview',
         'side-by-side',


### PR DESCRIPTION
## Summary
- extend MarkdownEditor to prompt for image size
- mention new editor feature in docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685fb2694c6c832183891f267f4c1469