### PR TITLE
Add assignment template support

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -271,7 +271,7 @@ func getTemplate(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 		return
 	}
-	c.File(*a.TemplatePath)
+       c.FileAttachment(*a.TemplatePath, filepath.Base(*a.TemplatePath))
 }
 
 // createTestCase: POST /api/assignments/:id/tests

--- a/backend/main.go
+++ b/backend/main.go
@@ -79,8 +79,11 @@ func main() {
 		api.PUT("/assignments/:id", RoleGuard("teacher", "admin"), updateAssignment)
 		api.DELETE("/assignments/:id", RoleGuard("teacher", "admin"), deleteAssignment)
 		api.PUT("/assignments/:id/publish", RoleGuard("teacher", "admin"), publishAssignment)
+		// allow optional trailing slash for template endpoints
 		api.POST("/assignments/:id/template", RoleGuard("teacher", "admin"), uploadTemplate)
+		api.POST("/assignments/:id/template/", RoleGuard("teacher", "admin"), uploadTemplate)
 		api.GET("/assignments/:id/template", RoleGuard("student", "teacher", "admin"), getTemplate)
+		api.GET("/assignments/:id/template/", RoleGuard("student", "teacher", "admin"), getTemplate)
 		api.POST("/assignments/:id/tests", RoleGuard("teacher", "admin"), createTestCase)
 		api.DELETE("/tests/:id", RoleGuard("teacher", "admin"), deleteTestCase)
 		api.POST("/assignments/:id/submissions", RoleGuard("student"), createSubmission)

--- a/backend/main.go
+++ b/backend/main.go
@@ -79,6 +79,8 @@ func main() {
 		api.PUT("/assignments/:id", RoleGuard("teacher", "admin"), updateAssignment)
 		api.DELETE("/assignments/:id", RoleGuard("teacher", "admin"), deleteAssignment)
 		api.PUT("/assignments/:id/publish", RoleGuard("teacher", "admin"), publishAssignment)
+		api.POST("/assignments/:id/template", RoleGuard("teacher", "admin"), uploadTemplate)
+		api.GET("/assignments/:id/template", RoleGuard("student", "teacher", "admin"), getTemplate)
 		api.POST("/assignments/:id/tests", RoleGuard("teacher", "admin"), createTestCase)
 		api.DELETE("/tests/:id", RoleGuard("teacher", "admin"), deleteTestCase)
 		api.POST("/assignments/:id/submissions", RoleGuard("student"), createSubmission)

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -12,6 +12,8 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS name TEXT;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS bk_class TEXT;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS bk_uid TEXT;
 
+ALTER TABLE assignments ADD COLUMN IF NOT EXISTS template_path TEXT;
+
 CREATE TABLE IF NOT EXISTS classes (
   id SERIAL PRIMARY KEY,
   name TEXT NOT NULL,
@@ -29,6 +31,7 @@ CREATE TABLE IF NOT EXISTS assignments (
   max_points INTEGER NOT NULL DEFAULT 100,
   grading_policy TEXT NOT NULL DEFAULT 'all_or_nothing' CHECK (grading_policy IN ('all_or_nothing','percentage','weighted')),
   published BOOLEAN NOT NULL DEFAULT FALSE,
+  template_path TEXT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   class_id INTEGER NOT NULL REFERENCES classes(id) ON DELETE CASCADE

--- a/frontend/src/routes/assignments/[id]/+page.svelte
+++ b/frontend/src/routes/assignments/[id]/+page.svelte
@@ -87,6 +87,22 @@ $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100)
     }catch(e:any){ err=e.message }
   }
 
+  async function downloadTemplate(){
+    try{
+      const res = await apiFetch(`/api/assignments/${id}/template`)
+      if(!res.ok) throw new Error('download failed')
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = assignment.template_path.split('/').pop()
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(url)
+    }catch(e:any){ err=e.message }
+  }
+
   function startEdit(){
     editing=true
     eTitle=assignment.title
@@ -194,7 +210,7 @@ $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100)
         <p><strong>Max points:</strong> {assignment.max_points}</p>
         <p><strong>Policy:</strong> {assignment.grading_policy}</p>
         {#if assignment.template_path}
-          <a class="link" href={`/api/assignments/${id}/template`} download>Download template</a>
+          <a class="link" href={`/api/assignments/${id}/template`} on:click|preventDefault={downloadTemplate}>Download template</a>
         {/if}
         {#if role==='teacher' || role==='admin'}
           <div class="mt-2 space-x-2">

--- a/frontend/src/routes/assignments/[id]/+page.svelte
+++ b/frontend/src/routes/assignments/[id]/+page.svelte
@@ -194,7 +194,7 @@ $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100)
         <p><strong>Max points:</strong> {assignment.max_points}</p>
         <p><strong>Policy:</strong> {assignment.grading_policy}</p>
         {#if assignment.template_path}
-          <a class="link" href={`/api/assignments/${id}/template`}>Download template</a>
+          <a class="link" href={`/api/assignments/${id}/template`} download>Download template</a>
         {/if}
         {#if role==='teacher' || role==='admin'}
           <div class="mt-2 space-x-2">

--- a/frontend/src/routes/assignments/[id]/+page.svelte
+++ b/frontend/src/routes/assignments/[id]/+page.svelte
@@ -25,6 +25,7 @@ const role = get(auth)?.role!;
   let err=''
   let tStdin='', tStdout='', tLimit=''
   let file:File|null=null
+  let templateFile:File|null=null
   let submitDialog: HTMLDialogElement;
 $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100) : 0;
   let editing=false
@@ -71,6 +72,17 @@ $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100)
         body:JSON.stringify({stdin:tStdin, expected_stdout:tStdout, time_limit_sec: parseFloat(tLimit) || undefined})
       })
       tStdin=tStdout=tLimit=''
+      await load()
+    }catch(e:any){ err=e.message }
+  }
+
+  async function uploadTemplate(){
+    if(!templateFile) return
+    const fd = new FormData()
+    fd.append('file', templateFile)
+    try{
+      await apiFetch(`/api/assignments/${id}/template`,{method:'POST', body:fd})
+      templateFile=null
       await load()
     }catch(e:any){ err=e.message }
   }
@@ -181,6 +193,15 @@ $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100)
         <p><strong>Deadline:</strong> {new Date(assignment.deadline).toLocaleString()}</p>
         <p><strong>Max points:</strong> {assignment.max_points}</p>
         <p><strong>Policy:</strong> {assignment.grading_policy}</p>
+        {#if assignment.template_path}
+          <a class="link" href={`/api/assignments/${id}/template`}>Download template</a>
+        {/if}
+        {#if role==='teacher' || role==='admin'}
+          <div class="mt-2 space-x-2">
+            <input type="file" class="file-input file-input-bordered" on:change={e=>templateFile=(e.target as HTMLInputElement).files?.[0] || null}>
+            <button class="btn" on:click={uploadTemplate} disabled={!templateFile}>Upload template</button>
+          </div>
+        {/if}
         {#if done}
           <p class="text-success font-bold">Assignment done.</p>
         {/if}


### PR DESCRIPTION
## Summary
- allow attaching `template_path` to assignments
- expose upload and download endpoints for templates
- display template upload & download controls in assignment page

## Testing
- `go test ./...`
- `npm run check` *(fails: `svelte-check` found errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fb29a6ee0832184e3bada63da42f3