### PR TITLE
Add file browser for submission view

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
 				"@tailwindcss/vite": "^4.1.11",
 				"daisyui": "^5.0.43",
 				"easymde": "^2.20.0",
+				"jszip": "^3.10.1",
 				"jwt-decode": "^4.0.0",
 				"marked": "^16.0.0",
 				"tailwindcss": "^4.1.11"
@@ -1442,6 +1443,12 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"license": "MIT"
+		},
 		"node_modules/daisyui": {
 			"version": "5.0.43",
 			"resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.43.tgz",
@@ -1725,6 +1732,18 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+			"license": "MIT"
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -1758,6 +1777,12 @@
 				"@types/estree": "^1.0.6"
 			}
 		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"license": "MIT"
+		},
 		"node_modules/jiti": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
@@ -1765,6 +1790,18 @@
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/jszip": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+			"license": "(MIT OR GPL-3.0-or-later)",
+			"dependencies": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"setimmediate": "^1.0.5"
 			}
 		},
 		"node_modules/jwt-decode": {
@@ -1784,6 +1821,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"immediate": "~3.0.5"
 			}
 		},
 		"node_modules/lightningcss": {
@@ -2133,6 +2179,12 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"license": "(MIT AND Zlib)"
+		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -2184,6 +2236,27 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"license": "MIT"
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"node_modules/readdirp": {
@@ -2273,11 +2346,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"license": "MIT"
+		},
 		"node_modules/set-cookie-parser": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
 			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
 			"license": "MIT"
 		},
 		"node_modules/sirv": {
@@ -2302,6 +2387,15 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
@@ -2483,6 +2577,12 @@
 			"resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.2.5.tgz",
 			"integrity": "sha512-F45vFWdGX8xahIk/sOp79z2NJs8ETMYsmMChm9D5Hlx3+9j7VnCyQyvij5MOCrNY3NNe8noSyokRjQRfq+Bc7A==",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
 		},
 		"node_modules/uuid": {
 			"version": "11.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,10 +26,11 @@
 		"vite-plugin-devtools-json": "^0.2.0"
 	},
 	"dependencies": {
-		"@tailwindcss/vite": "^4.1.11",
-		"daisyui": "^5.0.43",
-		"easymde": "^2.20.0",
-		"jwt-decode": "^4.0.0",
+                "@tailwindcss/vite": "^4.1.11",
+                "daisyui": "^5.0.43",
+                "easymde": "^2.20.0",
+                "jszip": "^3.10.1",
+                "jwt-decode": "^4.0.0",
                 "marked": "^16.0.0",
                 "@fortawesome/fontawesome-free": "^6.7.2",
                 "tailwindcss": "^4.1.11"

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -2,12 +2,16 @@
   import { onMount } from 'svelte'
   import { apiJSON } from '$lib/api'
   import { page } from '$app/stores'
+  import JSZip from 'jszip'
 
 $: id = $page.params.id
 
   let submission:any=null
   let results:any[]=[]
   let err=''
+  let files:{name:string,content:string}[]=[]
+  let selected:{name:string,content:string}|null=null
+  let fileDialog:HTMLDialogElement
 
   async function load(){
     err=''
@@ -15,6 +19,18 @@ $: id = $page.params.id
       const data = await apiJSON(`/api/submissions/${id}`)
       submission = data.submission
       results = data.results
+
+      files = []
+      try {
+        const zip = await JSZip.loadAsync(submission.code_content, { base64: true })
+        for (const file of Object.values(zip.files)) {
+          if (file.dir) continue
+          const content = await file.async('string')
+          files.push({ name: file.name, content })
+        }
+      } catch {
+        // fall back to showing raw base64 if it's not a zip
+      }
     }catch(e:any){ err=e.message }
   }
 
@@ -26,6 +42,11 @@ $: id = $page.params.id
     if(s==='wrong_output') return 'badge-error'
     if(s==='time_limit_exceeded' || s==='memory_limit_exceeded') return 'badge-warning'
     return ''
+  }
+
+  function openFile(f:{name:string,content:string}){
+    selected = f
+    fileDialog.showModal()
   }
 
   onMount(load)
@@ -42,9 +63,17 @@ $: id = $page.params.id
       </div>
     </div>
     <div class="card bg-base-100 shadow">
-      <div class="card-body">
-        <h3 class="card-title">File</h3>
-        <pre class="whitespace-pre-wrap">{submission.code_content}</pre>
+      <div class="card-body space-y-2">
+        <h3 class="card-title">Files</h3>
+        {#if files.length}
+          <ul class="menu">
+            {#each files as f}
+              <li><button class="btn btn-sm btn-outline w-full justify-between" on:click={() => openFile(f)}>{f.name}</button></li>
+            {/each}
+          </ul>
+        {:else}
+          <pre class="whitespace-pre-wrap">{submission.code_content}</pre>
+        {/if}
       </div>
     </div>
     <div class="card bg-base-100 shadow">
@@ -73,6 +102,14 @@ $: id = $page.params.id
     </div>
   </div>
 {/if}
+
+<dialog bind:this={fileDialog} class="modal">
+  <div class="modal-box w-11/12 max-w-3xl">
+    <h3 class="font-bold text-lg mb-2">{selected?.name}</h3>
+    <pre class="whitespace-pre-wrap">{selected?.content}</pre>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
 
 {#if err}<p style="color:red">{err}</p>{/if}
 


### PR DESCRIPTION
## Summary
- add jszip as frontend dependency
- parse uploaded zip files in submission page and list files
- allow viewing each file in a modal using daisyUI components
- improve file parsing logic

## Testing
- `go test ./...`
- `npm run check` *(fails: svelte-check found 3 errors and 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685fd78480588321b7d508581196107f