### PR TITLE
Improve submission file viewer

### DIFF
--- a/frontend/src/lib/FileTree.svelte
+++ b/frontend/src/lib/FileTree.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import FileTreeItem, { FileNode } from './FileTreeItem.svelte'
+  export let nodes: FileNode[] = []
+  export let select: (n: FileNode) => void
+</script>
+
+<ul class="menu bg-base-200 rounded">
+  {#each nodes as node}
+    <FileTreeItem {node} {select} />
+  {/each}
+</ul>

--- a/frontend/src/lib/FileTree.svelte
+++ b/frontend/src/lib/FileTree.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import FileTreeItem, { FileNode } from './FileTreeItem.svelte'
+  import FileTreeItem from './FileTreeItem.svelte'
+  import type { FileNode } from './FileTreeItem.svelte'
   export let nodes: FileNode[] = []
   export let select: (n: FileNode) => void
 </script>

--- a/frontend/src/lib/FileTreeItem.svelte
+++ b/frontend/src/lib/FileTreeItem.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  export interface FileNode {
+    name: string
+    content?: string
+    children?: FileNode[]
+  }
+  export let node: FileNode
+  export let select: (n: FileNode) => void
+  import FileTreeItem from './FileTreeItem.svelte'
+</script>
+
+<li>
+  {#if node.children}
+    <details class="ml-2">
+      <summary class="cursor-pointer">{node.name}</summary>
+      <ul class="menu pl-4">
+        {#each node.children as child}
+          <FileTreeItem {child} select={select} />
+        {/each}
+      </ul>
+    </details>
+  {:else}
+    <button class="btn btn-sm btn-ghost justify-start" on:click={() => select(node)}>{node.name}</button>
+  {/if}
+</li>

--- a/frontend/src/lib/FileTreeItem.svelte
+++ b/frontend/src/lib/FileTreeItem.svelte
@@ -15,7 +15,7 @@
       <summary class="cursor-pointer">{node.name}</summary>
       <ul class="menu pl-4">
         {#each node.children as child}
-          <FileTreeItem {child} select={select} />
+          <FileTreeItem node={child} select={select} />
         {/each}
       </ul>
     </details>

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -1,2 +1,3 @@
 // place files you want to import through the `$lib` alias in this folder.
 export { default as MarkdownEditor } from './MarkdownEditor.svelte';
+export { default as FileTree } from './FileTree.svelte';

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -36,7 +36,7 @@ $: id = $page.params.id
           files = [{ name: 'code', content: submission.code_content }]
         }
       }
-      if (files.length === 1) {
+      if (files.length) {
         selected = files[0]
       }
     } catch (e: any) {
@@ -54,9 +54,15 @@ $: id = $page.params.id
     return ''
   }
 
-  function openFile(f:{name:string,content:string}){
+  function openFiles() {
+    if (files.length) {
+      selected = files[0]
+      fileDialog.showModal()
+    }
+  }
+
+  function chooseFile(f: { name: string; content: string }) {
     selected = f
-    fileDialog.showModal()
   }
 
   onMount(load)
@@ -76,11 +82,7 @@ $: id = $page.params.id
       <div class="card-body space-y-2">
         <h3 class="card-title">Files</h3>
         {#if files.length}
-          <div class="flex flex-wrap gap-2">
-            {#each files as f}
-              <button class="btn btn-sm btn-outline" on:click={() => openFile(f)}>{f.name}</button>
-            {/each}
-          </div>
+          <button class="btn btn-primary" on:click={openFiles}>Show files</button>
         {:else}
           <pre class="whitespace-pre-wrap">{submission.code_content}</pre>
         {/if}
@@ -114,9 +116,19 @@ $: id = $page.params.id
 {/if}
 
 <dialog bind:this={fileDialog} class="modal">
-  <div class="modal-box w-11/12 max-w-3xl">
-    <h3 class="font-bold text-lg mb-2">{selected?.name}</h3>
-    <pre class="whitespace-pre-wrap">{selected?.content}</pre>
+  <div class="modal-box w-11/12 max-w-5xl">
+    <div class="flex flex-col md:flex-row gap-4">
+      <ul class="menu bg-base-200 rounded md:w-60">
+        {#each files as f}
+          <li class={selected?.name === f.name ? 'active' : ''}>
+            <button on:click={() => chooseFile(f)}>{f.name}</button>
+          </li>
+        {/each}
+      </ul>
+      <pre class="flex-1 whitespace-pre-wrap bg-base-200 p-2 rounded">
+        {selected?.content}
+      </pre>
+    </div>
   </div>
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -81,11 +81,7 @@ $: id = $page.params.id
     <div class="card bg-base-100 shadow">
       <div class="card-body space-y-2">
         <h3 class="card-title">Files</h3>
-        {#if files.length}
-          <button class="btn btn-primary" on:click={openFiles}>Show files</button>
-        {:else}
-          <pre class="whitespace-pre-wrap">{submission.code_content}</pre>
-        {/if}
+        <button class="btn btn-primary" on:click={openFiles}>Show files</button>
       </div>
     </div>
     <div class="card bg-base-100 shadow">
@@ -117,18 +113,24 @@ $: id = $page.params.id
 
 <dialog bind:this={fileDialog} class="modal">
   <div class="modal-box w-11/12 max-w-5xl">
-    <div class="flex flex-col md:flex-row gap-4">
-      <ul class="menu bg-base-200 rounded md:w-60">
-        {#each files as f}
-          <li class={selected?.name === f.name ? 'active' : ''}>
-            <button on:click={() => chooseFile(f)}>{f.name}</button>
-          </li>
-        {/each}
-      </ul>
-      <pre class="flex-1 whitespace-pre-wrap bg-base-200 p-2 rounded">
-        {selected?.content}
+    {#if files.length}
+      <div class="flex flex-col md:flex-row gap-4">
+        <ul class="menu bg-base-200 rounded md:w-60">
+          {#each files as f}
+            <li class={selected?.name === f.name ? 'active' : ''}>
+              <button on:click={() => chooseFile(f)}>{f.name}</button>
+            </li>
+          {/each}
+        </ul>
+        <pre class="flex-1 whitespace-pre-wrap bg-base-200 p-2 rounded">
+          {selected?.content}
+        </pre>
+      </div>
+    {:else}
+      <pre class="whitespace-pre-wrap bg-base-200 p-2 rounded">
+        {submission.code_content}
       </pre>
-    </div>
+    {/if}
   </div>
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -31,20 +31,19 @@ $: id = $page.params.id
       files = []
       tree = []
       try {
-        const bytes = Uint8Array.from(atob(submission.code_content), c => c.charCodeAt(0))
-        try {
-          const zip = await JSZip.loadAsync(bytes)
-          for (const file of Object.values(zip.files)) {
-            if (file.dir) continue
-            const content = await file.async('string')
-            files.push({ name: file.name, content })
-          }
-        } catch {
-          const text = new TextDecoder().decode(bytes)
-          files = [{ name: 'code', content: text }]
+        const zip = await JSZip.loadAsync(submission.code_content, { base64: true })
+        for (const file of Object.values(zip.files)) {
+          if (file.dir) continue
+          const content = await file.async('string')
+          files.push({ name: file.name, content })
         }
       } catch {
-        files = [{ name: 'code', content: submission.code_content }]
+        try {
+          const text = atob(submission.code_content)
+          files = [{ name: 'code', content: text }]
+        } catch {
+          files = [{ name: 'code', content: submission.code_content }]
+        }
       }
 
       if (files.length) {

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -9,13 +9,13 @@ $: id = $page.params.id
   let submission:any=null
   let results:any[]=[]
   let err=''
-  let files:{name:string,content:string}[]=[]
-  let selected:{name:string,content:string}|null=null
-  let fileDialog:HTMLDialogElement
+  let files: { name: string; content: string }[] = []
+  let selected: { name: string; content: string } | null = null
+  let fileDialog: HTMLDialogElement
 
-  async function load(){
-    err=''
-    try{
+  async function load() {
+    err = ''
+    try {
       const data = await apiJSON(`/api/submissions/${id}`)
       submission = data.submission
       results = data.results
@@ -29,9 +29,19 @@ $: id = $page.params.id
           files.push({ name: file.name, content })
         }
       } catch {
-        // fall back to showing raw base64 if it's not a zip
+        // not a zip, decode as single file
+        try {
+          files = [{ name: 'code', content: atob(submission.code_content) }]
+        } catch {
+          files = [{ name: 'code', content: submission.code_content }]
+        }
       }
-    }catch(e:any){ err=e.message }
+      if (files.length === 1) {
+        selected = files[0]
+      }
+    } catch (e: any) {
+      err = e.message
+    }
   }
 
   function statusColor(s:string){
@@ -66,11 +76,11 @@ $: id = $page.params.id
       <div class="card-body space-y-2">
         <h3 class="card-title">Files</h3>
         {#if files.length}
-          <ul class="menu">
+          <div class="flex flex-wrap gap-2">
             {#each files as f}
-              <li><button class="btn btn-sm btn-outline w-full justify-between" on:click={() => openFile(f)}>{f.name}</button></li>
+              <button class="btn btn-sm btn-outline" on:click={() => openFile(f)}>{f.name}</button>
             {/each}
-          </ul>
+          </div>
         {:else}
           <pre class="whitespace-pre-wrap">{submission.code_content}</pre>
         {/if}

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -128,7 +128,7 @@ $: id = $page.params.id
       </div>
     {:else}
       <pre class="whitespace-pre-wrap bg-base-200 p-2 rounded">
-        {submission.code_content}
+        {submission?.code_content}
       </pre>
     {/if}
   </div>


### PR DESCRIPTION
## Summary
- show uploaded files in a nicer list
- decode single-file submissions automatically
- open selected file in modal

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685fe06b98e08321be7023ed08f6ebac