### PR TITLE
Prevent navigation after deleting assignment in class view

### DIFF
--- a/frontend/src/routes/classes/[id]/+page.svelte
+++ b/frontend/src/routes/classes/[id]/+page.svelte
@@ -209,7 +209,7 @@ import { marked } from 'marked';
                       <span class="badge badge-success">done</span>
                     {/if}
                     {#if role === 'teacher' || role === 'admin'}
-                      <button class="btn btn-xs btn-error" on:click|stopPropagation={()=>deleteAssignment(a.id)}>Delete</button>
+                      <button class="btn btn-xs btn-error" on:click|preventDefault|stopPropagation={() => deleteAssignment(a.id)}>Delete</button>
                     {/if}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- stop automatic navigation when the delete button is clicked on a class assignment

## Testing
- `npm run build` in `frontend`
- `go test ./...` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685ff338c69c8321a8b25e7ca3fbd343