### PR TITLE
Add syntax highlighting in submission file viewer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
 				"@tailwindcss/vite": "^4.1.11",
 				"daisyui": "^5.0.43",
 				"easymde": "^2.20.0",
+				"highlight.js": "^11.11.1",
 				"jszip": "^3.10.1",
 				"jwt-decode": "^4.0.0",
 				"marked": "^16.0.0",
@@ -1730,6 +1731,15 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/highlight.js": {
+			"version": "11.11.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/immediate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,13 +26,14 @@
 		"vite-plugin-devtools-json": "^0.2.0"
 	},
 	"dependencies": {
-                "@tailwindcss/vite": "^4.1.11",
-                "daisyui": "^5.0.43",
-                "easymde": "^2.20.0",
-                "jszip": "^3.10.1",
-                "jwt-decode": "^4.0.0",
-                "marked": "^16.0.0",
-                "@fortawesome/fontawesome-free": "^6.7.2",
-                "tailwindcss": "^4.1.11"
-        }
+		"@fortawesome/fontawesome-free": "^6.7.2",
+		"@tailwindcss/vite": "^4.1.11",
+		"daisyui": "^5.0.43",
+		"easymde": "^2.20.0",
+		"highlight.js": "^11.11.1",
+		"jszip": "^3.10.1",
+		"jwt-decode": "^4.0.0",
+		"marked": "^16.0.0",
+		"tailwindcss": "^4.1.11"
+	}
 }

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -13,6 +13,10 @@ $: id = $page.params.id
   let files: { name: string; content: string }[] = []
   let tree: FileNode[] = []
   let selected: { name: string; content: string } | null = null
+  let highlighted = ''
+
+  import hljs from 'highlight.js'
+  import 'highlight.js/styles/github.css'
   let fileDialog: HTMLDialogElement
 
   interface FileNode {
@@ -107,6 +111,14 @@ $: id = $page.params.id
     }
   }
 
+  $: if (selected) {
+    highlighted = hljs.highlightAuto(selected.content).value
+  }
+
+  $: if (!selected && submission) {
+    highlighted = hljs.highlightAuto(submission.code_content).value
+  }
+
   onMount(load)
 </script>
 
@@ -160,14 +172,13 @@ $: id = $page.params.id
         <div class="md:w-60">
           <FileTree nodes={tree} select={chooseFile} />
         </div>
-        <pre class="flex-1 whitespace-pre-wrap bg-base-200 p-2 rounded">
-          {selected?.content}
-        </pre>
+        <div class="flex-1">
+          <div class="font-mono text-sm mb-2">{selected?.name}</div>
+          <pre class="whitespace-pre bg-base-200 p-2 rounded"><code class="hljs">{@html highlighted}</code></pre>
+        </div>
       </div>
     {:else}
-      <pre class="whitespace-pre-wrap bg-base-200 p-2 rounded">
-        {submission?.code_content}
-      </pre>
+      <pre class="whitespace-pre bg-base-200 p-2 rounded"><code class="hljs">{@html highlighted}</code></pre>
     {/if}
   </div>
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
@@ -176,9 +187,12 @@ $: id = $page.params.id
 {#if err}<p style="color:red">{err}</p>{/if}
 
 <style>
-pre{
-  background:#eee;
-  padding:.5rem;
-  overflow:auto;
+pre {
+  background: #eee;
+  padding: .5rem;
+  overflow: auto;
+}
+.hljs {
+  background: transparent;
 }
 </style>


### PR DESCRIPTION
## Summary
- use highlight.js in the submission file viewer dialog
- show file name and render highlighted HTML
- include highlight.js dependency

## Testing
- `npm run build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68606aa9c6608321b05e4a727d2d5d37