### PR TITLE
Add line numbers to file viewer

### DIFF
--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -15,6 +15,13 @@ $: id = $page.params.id
   let selected: { name: string; content: string } | null = null
   let highlighted = ''
 
+  function addLineNumbers(html: string) {
+    return html
+      .split('\n')
+      .map((line) => `<span class="line">${line}</span>`) 
+      .join('\n')
+  }
+
   import hljs from 'highlight.js'
   import 'highlight.js/styles/github.css'
   let fileDialog: HTMLDialogElement
@@ -112,11 +119,11 @@ $: id = $page.params.id
   }
 
   $: if (selected) {
-    highlighted = hljs.highlightAuto(selected.content).value
+    highlighted = addLineNumbers(hljs.highlightAuto(selected.content).value)
   }
 
   $: if (!selected && submission) {
-    highlighted = hljs.highlightAuto(submission.code_content).value
+    highlighted = addLineNumbers(hljs.highlightAuto(submission.code_content).value)
   }
 
   onMount(load)
@@ -174,11 +181,11 @@ $: id = $page.params.id
         </div>
         <div class="flex-1">
           <div class="font-mono text-sm mb-2">{selected?.name}</div>
-          <pre class="whitespace-pre bg-base-200 p-2 rounded"><code class="hljs">{@html highlighted}</code></pre>
+          <pre class="whitespace-pre bg-base-200 p-2 rounded"><code class="hljs line-numbers">{@html highlighted}</code></pre>
         </div>
       </div>
     {:else}
-      <pre class="whitespace-pre bg-base-200 p-2 rounded"><code class="hljs">{@html highlighted}</code></pre>
+      <pre class="whitespace-pre bg-base-200 p-2 rounded"><code class="hljs line-numbers">{@html highlighted}</code></pre>
     {/if}
   </div>
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
@@ -194,5 +201,26 @@ pre {
 }
 .hljs {
   background: transparent;
+}
+
+code.line-numbers {
+  counter-reset: line;
+}
+
+.line {
+  display: block;
+  padding-left: 3em;
+  position: relative;
+}
+
+.line::before {
+  counter-increment: line;
+  content: counter(line);
+  position: absolute;
+  left: 0;
+  width: 2.5em;
+  text-align: right;
+  padding-right: 0.5em;
+  color: #888;
 }
 </style>

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -203,17 +203,17 @@ pre {
   background: transparent;
 }
 
-code.line-numbers {
+:global(code.line-numbers) {
   counter-reset: line;
 }
 
-.line {
+:global(.line) {
   display: block;
   padding-left: 3em;
   position: relative;
 }
 
-.line::before {
+:global(.line::before) {
   counter-increment: line;
   content: counter(line);
   position: absolute;

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -181,11 +181,11 @@ $: id = $page.params.id
         </div>
         <div class="flex-1">
           <div class="font-mono text-sm mb-2">{selected?.name}</div>
-          <pre class="whitespace-pre bg-base-200 p-2 rounded"><code class="hljs line-numbers">{@html highlighted}</code></pre>
+          <pre class="whitespace-pre bg-base-200 p-2 rounded font-mono text-sm"><code class="hljs line-numbers">{@html highlighted}</code></pre>
         </div>
       </div>
     {:else}
-      <pre class="whitespace-pre bg-base-200 p-2 rounded"><code class="hljs line-numbers">{@html highlighted}</code></pre>
+      <pre class="whitespace-pre bg-base-200 p-2 rounded font-mono text-sm"><code class="hljs line-numbers">{@html highlighted}</code></pre>
     {/if}
   </div>
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
@@ -198,6 +198,8 @@ pre {
   background: #eee;
   padding: .5rem;
   overflow: auto;
+  font-family: monospace;
+  line-height: 1.25;
 }
 .hljs {
   background: transparent;
@@ -205,12 +207,14 @@ pre {
 
 :global(code.line-numbers) {
   counter-reset: line;
+  font-variant-numeric: tabular-nums;
 }
 
 :global(.line) {
   display: block;
   padding-left: 3em;
   position: relative;
+  line-height: 1.25;
 }
 
 :global(.line::before) {
@@ -222,5 +226,7 @@ pre {
   text-align: right;
   padding-right: 0.5em;
   color: #888;
+  font-family: inherit;
 }
+
 </style>


### PR DESCRIPTION
## Summary
- add `addLineNumbers` helper
- use it to wrap highlighted code in the submissions popup
- style `.line-numbers` and `.line` elements for numbered lines

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68606fe2f9548321bcc0aaad3469cfea