### PR TITLE
Fix dashboard for users with no classes

### DIFF
--- a/frontend/src/routes/assignments/+layout.svelte
+++ b/frontend/src/routes/assignments/+layout.svelte
@@ -8,7 +8,8 @@
 
   onMount(async () => {
     try {
-      classes = await apiJSON('/api/classes');
+      const result = await apiJSON('/api/classes');
+      classes = Array.isArray(result) ? result : [];
     } catch (e:any) { err = e.message }
   });
 </script>

--- a/frontend/src/routes/classes/+layout.svelte
+++ b/frontend/src/routes/classes/+layout.svelte
@@ -9,7 +9,8 @@
 
   onMount(async () => {
     try {
-      classes = await apiJSON('/api/classes');
+      const result = await apiJSON('/api/classes');
+      classes = Array.isArray(result) ? result : [];
     } catch (e:any) { err = e.message }
   });
 </script>

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -22,7 +22,8 @@
         loading = false;
         return;
       }
-      classes = await apiJSON('/api/classes');
+      const result = await apiJSON('/api/classes');
+      classes = Array.isArray(result) ? result : [];
 
       if (role === 'student') {
         submissions = await apiJSON('/api/my-submissions');

--- a/frontend/src/routes/my-classes/+page.svelte
+++ b/frontend/src/routes/my-classes/+page.svelte
@@ -6,7 +6,10 @@
   let list:Class[]=[];
   let err='';
   onMount(async()=>{
-    try { list = await apiJSON('/api/classes'); }
+    try {
+      const result = await apiJSON('/api/classes');
+      list = Array.isArray(result) ? result : [];
+    }
     catch(e:any){ err=e.message }
   });
 </script>


### PR DESCRIPTION
## Summary
- guard GET /api/classes result before looping

## Testing
- `npm run check`
- `npm run build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6860f84af0c0832197bf6f02fb4c9242