### PR TITLE
Fix assignment HTML injection

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
 				"@fortawesome/fontawesome-free": "^6.7.2",
 				"@tailwindcss/vite": "^4.1.11",
 				"daisyui": "^5.0.43",
+				"dompurify": "^3.2.6",
 				"easymde": "^2.20.0",
 				"highlight.js": "^11.11.1",
 				"jszip": "^3.10.1",
@@ -1329,6 +1330,13 @@
 				"@types/estree": "*"
 			}
 		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/@yr/monotone-cubic-spline": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
@@ -1503,6 +1511,15 @@
 			"integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/dompurify": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+			"integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
+			}
 		},
 		"node_modules/easymde": {
 			"version": "2.20.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
 		"@fortawesome/fontawesome-free": "^6.7.2",
 		"@tailwindcss/vite": "^4.1.11",
 		"daisyui": "^5.0.43",
+		"dompurify": "^3.2.6",
 		"easymde": "^2.20.0",
 		"highlight.js": "^11.11.1",
 		"jszip": "^3.10.1",

--- a/frontend/src/routes/assignments/[id]/+page.svelte
+++ b/frontend/src/routes/assignments/[id]/+page.svelte
@@ -5,6 +5,7 @@ import { onMount, onDestroy } from 'svelte'
 import { apiFetch, apiJSON } from '$lib/api'
 import { MarkdownEditor } from '$lib'
 import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 import { goto } from '$app/navigation'
 import { page } from '$app/stores'
 
@@ -33,6 +34,8 @@ const role = get(auth)?.role!;
 $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100) : 0;
   let editing=false
   let eTitle='', eDesc='', eDeadline='', ePoints=0, ePolicy='all_or_nothing'
+  let safeDesc=''
+$: safeDesc = assignment ? DOMPurify.sanitize(marked.parse(assignment.description) as string) : ''
 
   async function publish(){
     try{
@@ -234,7 +237,7 @@ $: percent = assignment ? Math.round(pointsEarned / assignment.max_points * 100)
             </div>
           {/if}
         </div>
-        <div class="markdown">{@html marked.parse(assignment.description)}</div>
+        <div class="markdown">{@html safeDesc}</div>
         <p><strong>Deadline:</strong> {new Date(assignment.deadline).toLocaleString()}</p>
         <p><strong>Max points:</strong> {assignment.max_points}</p>
         <p><strong>Policy:</strong> {assignment.grading_policy}</p>


### PR DESCRIPTION
## Summary
- sanitize assignment descriptions in the assignment page
- add `dompurify` dependency to sanitize HTML

## Testing
- `npm run check` *(fails: FileTree.svelte export error)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68610be086288321b630e3849ce6bdd6