### PR TITLE
Enforce custom ADMIN_PASSWORD

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 DATABASE_URL=postgres://codegrader_user:supersecret@127.0.0.1:48812/codegrader_db?sslmode=disable
 JWT_SECRET=change_me
 ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=admin123
+# Use a strong password; startup fails if empty or set to 'admin123'
+ADMIN_PASSWORD=change_me
 BAKALARI_BASE_URL=https://bakalari.example.com

--- a/backend/main.go
+++ b/backend/main.go
@@ -19,8 +19,8 @@ func ensureAdmin() {
 		email = "admin@example.com"
 	}
 	password := os.Getenv("ADMIN_PASSWORD")
-	if password == "" {
-		password = "admin123"
+	if password == "" || password == "admin123" {
+		log.Fatal("ADMIN_PASSWORD must be set to a non-default value")
 	}
 
 	hashed := clientHash(password)


### PR DESCRIPTION
## Summary
- require ADMIN_PASSWORD to be non-empty and not the default `admin123`
- document requirement in `.env.example`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68610be757048321ab5285960d214b27