### PR TITLE
Add class management for teachers

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -474,6 +474,40 @@ func createClass(c *gin.Context) {
 	c.JSON(http.StatusCreated, cl)
 }
 
+func updateClass(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var req struct {
+		Name string `json:"name" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	cl := &Class{ID: id, Name: req.Name}
+	if err := UpdateClass(cl); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, cl)
+}
+
+func deleteClass(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := DeleteClass(id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
 // ---- TEACHER adds students to an existing class ----
 func addStudents(c *gin.Context) {
 	classID, _ := strconv.Atoi(c.Param("id"))

--- a/backend/main.go
+++ b/backend/main.go
@@ -99,6 +99,8 @@ func main() {
 
 		// TEACHER only
 		api.POST("/classes", RoleGuard("teacher"), createClass)
+		api.PUT("/classes/:id", RoleGuard("teacher", "admin"), updateClass)
+		api.DELETE("/classes/:id", RoleGuard("teacher", "admin"), deleteClass)
 
 		// Assignments now tied to class
 		api.POST("/classes/:id/assignments", RoleGuard("teacher", "admin"), createAssignment)

--- a/backend/models.go
+++ b/backend/models.go
@@ -237,6 +237,23 @@ func CreateClass(c *Class) error {
 	).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt)
 }
 
+func UpdateClass(c *Class) error {
+	res, err := DB.Exec(`UPDATE classes SET name=$1, updated_at=now() WHERE id=$2`,
+		c.Name, c.ID)
+	if err != nil {
+		return err
+	}
+	if cnt, _ := res.RowsAffected(); cnt == 0 {
+		return fmt.Errorf("not found")
+	}
+	return nil
+}
+
+func DeleteClass(id int) error {
+	_, err := DB.Exec(`DELETE FROM classes WHERE id=$1`, id)
+	return err
+}
+
 func AddStudentsToClass(classID int, studentIDs []int) error {
 	tx, err := DB.Beginx()
 	if err != nil {

--- a/backend/models_test.go
+++ b/backend/models_test.go
@@ -40,3 +40,44 @@ func TestListClassesForTeacher(t *testing.T) {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+func TestUpdateClass(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to open sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	DB = sqlx.NewDb(db, "sqlmock")
+
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE classes SET name=$1, updated_at=now() WHERE id=$2`)).
+		WithArgs("New", 5).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	c := &Class{ID: 5, Name: "New"}
+	if err := UpdateClass(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestDeleteClass(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to open sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	DB = sqlx.NewDb(db, "sqlmock")
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM classes WHERE id=$1`)).
+		WithArgs(3).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := DeleteClass(3); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { apiJSON } from '$lib/api';
+  import { apiJSON, apiFetch } from '$lib/api';
   import AdminPanel from '$lib/AdminPanel.svelte';
 
   let role = '';

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -9,6 +9,7 @@
   let upcoming:any[] = [];
   let loading = true;
   let err = '';
+  let className='';
 
   function percent(done:number,total:number){
     return total ? Math.round((done/total)*100) : 0;
@@ -65,6 +66,22 @@
     }
     loading = false;
   });
+
+  async function createClass(){
+    try{
+      await apiFetch('/api/classes',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({name:className})
+      });
+      className='';
+      // reload list
+      const result = await apiJSON('/api/classes');
+      classes = Array.isArray(result) ? result : [];
+    }catch(e:any){
+      err=e.message;
+    }
+  }
 </script>
 
 {#if loading}
@@ -132,6 +149,12 @@
         </a>
       {/each}
     </div>
+    <form class="mt-6" on:submit|preventDefault={createClass}>
+      <div class="join">
+        <input class="input input-bordered join-item" placeholder="Class name" bind:value={className} required />
+        <button class="btn join-item" disabled={!className}>Create</button>
+      </div>
+    </form>
   {:else if role === 'admin'}
     <AdminPanel />
   {/if}


### PR DESCRIPTION
## Summary
- allow teachers to rename or delete classes
- expose `PUT/DELETE /api/classes/:id` endpoints
- support class creation from the dashboard
- add unit tests for new class model helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68610e00a24083219800051587aa0ff4