### PR TITLE
Associate SSE events with user ID

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -674,17 +673,4 @@ func removeStudent(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusNoContent)
-}
-
-// eventsHandler streams submission updates to clients using SSE.
-func eventsHandler(c *gin.Context) {
-	ch := addSubscriber()
-	defer removeSubscriber(ch)
-	c.Stream(func(w io.Writer) bool {
-		if evt, ok := <-ch; ok {
-			c.SSEvent(evt.Event, evt.Data)
-			return true
-		}
-		return false
-	})
 }


### PR DESCRIPTION
## Summary
- attach a user ID to each SSE subscriber
- only broadcast events relevant to the subscriber's submissions
- clean up imports in handlers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68610bc4068c832184231a8d5d4a328e