### PR TITLE
Enhance sidebar icons and active style

### DIFF
--- a/frontend/src/lib/Sidebar.svelte
+++ b/frontend/src/lib/Sidebar.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { apiJSON } from '$lib/api';
   import { page } from '$app/stores';
+  import '@fortawesome/fontawesome-free/css/all.min.css';
   let classes:any[] = [];
   let err = '';
   onMount(async () => {
@@ -16,7 +17,13 @@
   <ul class="menu">
     {#each classes as c}
       <li>
-        <a class={$page.params.id == c.id.toString() ? 'active' : ''} href={`/classes/${c.id}`}>{c.name}</a>
+        <a
+          class={`flex items-center gap-2 ${$page.params.id == c.id.toString() ? 'bg-primary/20 font-semibold' : ''}`}
+          href={`/classes/${c.id}`}
+        >
+          <i class="fa-solid fa-book"></i>
+          {c.name}
+        </a>
       </li>
     {/each}
     {#if !classes.length && !err}


### PR DESCRIPTION
## Summary
- add global FontAwesome import to `Sidebar.svelte`
- display a book icon before each class name
- highlight the active class link with `bg-primary/20 font-semibold`

## Testing
- `npm run check`
- `go test ./...` *(fails: expected 403, got 404)*

------
https://chatgpt.com/codex/tasks/task_e_686287c741d88321bc11678de99f58ad