### PR TITLE
Add responsive sidebar toggle

### DIFF
--- a/frontend/src/lib/Sidebar.svelte
+++ b/frontend/src/lib/Sidebar.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { apiJSON } from '$lib/api';
   import { page } from '$app/stores';
+  import { sidebarOpen } from '$lib/sidebar';
   let classes:any[] = [];
   let err = '';
   onMount(async () => {
@@ -11,12 +12,29 @@
     } catch(e:any){ err = e.message }
   });
 </script>
-<aside class="w-60 bg-base-200 p-4 h-screen fixed top-0 left-0 overflow-y-auto">
+<aside
+  class={`fixed top-0 left-0 z-40 w-60 bg-base-200 p-4 h-screen overflow-y-auto transition-transform relative
+      ${$sidebarOpen ? 'block translate-x-0' : 'hidden -translate-x-full'}
+      sm:block sm:translate-x-0`}
+>
+  <button
+    class="btn btn-square btn-ghost absolute right-2 top-2 sm:hidden"
+    on:click={() => sidebarOpen.set(false)}
+    aria-label="Close sidebar"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  </button>
   <h2 class="font-bold mb-2">Classes</h2>
   <ul class="menu">
     {#each classes as c}
       <li>
-        <a class={$page.params.id == c.id.toString() ? 'active' : ''} href={`/classes/${c.id}`}>{c.name}</a>
+        <a
+          class={$page.params.id == c.id.toString() ? 'active' : ''}
+          href={`/classes/${c.id}`}
+          on:click={() => sidebarOpen.set(false)}
+        >{c.name}</a>
       </li>
     {/each}
     {#if !classes.length && !err}

--- a/frontend/src/lib/sidebar.ts
+++ b/frontend/src/lib/sidebar.ts
@@ -1,0 +1,4 @@
+import { writable } from 'svelte/store';
+
+/** controls whether the sidebar is open on small screens */
+export const sidebarOpen = writable(false);

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import { onMount } from 'svelte';
   import '../app.css';
   import Sidebar from '$lib/Sidebar.svelte';
+  import { sidebarOpen } from '$lib/sidebar';
 
   function logout() {
     auth.logout();
@@ -21,9 +22,30 @@
     <Sidebar />
   {/if}
 
-  <div class={`min-h-screen flex flex-col ${user ? 'ml-60' : ''}`}>
+  <div class={`min-h-screen flex flex-col ${user ? 'sm:ml-60' : ''}`}>
     <div class="navbar bg-base-200 shadow">
       <div class="flex-1">
+        {#if user}
+          <button
+            class="btn btn-square btn-ghost mr-2 sm:hidden"
+            on:click={() => sidebarOpen.update((v) => !v)}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              class="w-6 h-6"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            </svg>
+          </button>
+        {/if}
         <a href="/dashboard" class="btn btn-ghost text-xl">CodeGrader</a>
         {#if user?.role === 'admin'}
           <!-- admin uses dashboard -->


### PR DESCRIPTION
## Summary
- create a `sidebarOpen` store
- make the sidebar responsive and bind to the store
- add hamburger button that toggles the sidebar
- adjust page layout margin for large screens
- add close button inside sidebar for mobile
- close sidebar after selecting a link on small screens

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686287c0023c83219e7febfbcf5e84e8