### PR TITLE
Detect missing frontend build

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -119,6 +119,9 @@ func main() {
 
 	// 5) Frontend
 	buildPath := filepath.Join("..", "frontend", "build")
+	if _, err := os.Stat(filepath.Join(buildPath, "index.html")); err != nil {
+		log.Fatalf("frontend not built: %v. Run 'npm run build' inside the frontend directory", err)
+	}
 
 	// serve built assets without conflicting with /api routes
 	r.Static("/_app", filepath.Join(buildPath, "_app"))


### PR DESCRIPTION
## Summary
- fail fast if the frontend build directory is missing

## Testing
- `go test ./...` *(fails: TestGetAssignmentStudentForbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6862a9d3473c83218309dc504a0104e8