### PR TITLE
Fix sidebar layout margin

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -22,7 +22,10 @@
     <Sidebar />
   {/if}
 
-  <div class={`min-h-screen flex flex-col ${user ? 'sm:ml-60' : ''}`}>
+  <div
+    class="min-h-screen flex flex-col sm:ml-60"
+    style:margin-left={!user ? '0' : undefined}
+  >
     <div class="navbar bg-base-200 shadow">
       <div class="flex-1">
         {#if user}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -22,10 +22,7 @@
     <Sidebar />
   {/if}
 
-  <div
-    class="min-h-screen flex flex-col sm:ml-60"
-    style:margin-left={!user ? '0' : undefined}
-  >
+  <div class="min-h-screen flex flex-col" class:sm\\:ml-60={user}>
     <div class="navbar bg-base-200 shadow">
       <div class="flex-1">
         {#if user}


### PR DESCRIPTION
## Summary
- ensure main layout shifts right only when sidebar visible

## Testing
- `go test ./...` *(fails: TestGetAssignmentStudentForbidden)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6862b3cb919c832181584dba8552848c