### PR TITLE
Fix sticky navbar

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -23,7 +23,7 @@
   {/if}
 
   <div class={`min-h-screen flex flex-col ${user ? 'sm:ml-60' : ''}`}>
-    <div class="navbar bg-base-200 shadow">
+    <div class="navbar bg-base-200 shadow sticky top-0 z-50">
       <div class="flex-1">
         {#if user}
           <button


### PR DESCRIPTION
## Summary
- keep the navbar at the top of the screen when scrolling

## Testing
- `npm run build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6863bd701f0483219e3fc6f8e68c2fc3