### PR TITLE
Late submission points and teacher override

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -86,6 +86,7 @@ func main() {
 		api.DELETE("/tests/:id", RoleGuard("teacher", "admin"), deleteTestCase)
 		api.POST("/assignments/:id/submissions", RoleGuard("student"), createSubmission)
 		api.GET("/submissions/:id", RoleGuard("student", "teacher", "admin"), getSubmission)
+		api.PUT("/submissions/:id/points", RoleGuard("teacher", "admin"), overrideSubmissionPoints)
 		// TEACHER / STUDENT common
 		api.GET("/classes", RoleGuard("teacher", "student"), myClasses)
 		api.POST("/classes/:id/students", RoleGuard("teacher", "admin"), addStudents)

--- a/backend/models.go
+++ b/backend/models.go
@@ -49,6 +49,8 @@ type Submission struct {
 	CodePath     string    `db:"code_path" json:"code_path"`
 	CodeContent  string    `db:"code_content" json:"code_content"`
 	Status       string    `db:"status" json:"status"`
+	Points       *float64  `db:"points" json:"points"`
+	OverridePts  *float64  `db:"override_points" json:"override_points"`
 	CreatedAt    time.Time `db:"created_at" json:"created_at"`
 	UpdatedAt    time.Time `db:"updated_at" json:"updated_at"`
 }
@@ -466,7 +468,7 @@ func DeleteUser(id int) error {
 func ListSubmissionsForStudent(studentID int) ([]Submission, error) {
 	subs := []Submission{}
 	err := DB.Select(&subs, `
-               SELECT id, assignment_id, student_id, code_path, code_content, status, created_at, updated_at
+               SELECT id, assignment_id, student_id, code_path, code_content, status, points, override_points, created_at, updated_at
                  FROM submissions
                 WHERE student_id = $1
                 ORDER BY created_at DESC`, studentID)
@@ -502,7 +504,7 @@ type SubmissionWithStudent struct {
 func ListSubmissionsForAssignmentAndStudent(aid, sid int) ([]SubmissionWithReason, error) {
 	subs := []SubmissionWithReason{}
 	err := DB.Select(&subs, `
-               SELECT id, assignment_id, student_id, code_path, code_content, status, created_at, updated_at,
+               SELECT id, assignment_id, student_id, code_path, code_content, status, points, override_points, created_at, updated_at,
                       (SELECT r.status FROM results r
                          WHERE r.submission_id = submissions.id AND r.status <> 'passed'
                          ORDER BY r.id LIMIT 1) AS failure_reason
@@ -517,7 +519,7 @@ func ListSubmissionsForAssignmentAndStudent(aid, sid int) ([]SubmissionWithReaso
 func ListSubmissionsForAssignment(aid int) ([]SubmissionWithStudent, error) {
 	subs := []SubmissionWithStudent{}
 	err := DB.Select(&subs, `
-               SELECT s.id, s.assignment_id, s.student_id, s.code_path, s.code_content, s.status, s.created_at, s.updated_at,
+               SELECT s.id, s.assignment_id, s.student_id, s.code_path, s.code_content, s.status, s.points, s.override_points, s.created_at, s.updated_at,
                      u.email, u.name,
                      (SELECT r.status FROM results r
                         WHERE r.submission_id = s.id AND r.status <> 'passed'
@@ -596,7 +598,7 @@ type Result struct {
 func GetSubmission(id int) (*Submission, error) {
 	var s Submission
 	err := DB.Get(&s, `
-        SELECT id, assignment_id, student_id, code_path, code_content, status, created_at, updated_at
+        SELECT id, assignment_id, student_id, code_path, code_content, status, points, override_points, created_at, updated_at
           FROM submissions
          WHERE id=$1`, id)
 	if err != nil {
@@ -634,4 +636,14 @@ func ListResultsForSubmission(subID int) ([]Result, error) {
          WHERE submission_id=$1
          ORDER BY id`, subID)
 	return list, err
+}
+
+func SetSubmissionPoints(id int, pts float64) error {
+	_, err := DB.Exec(`UPDATE submissions SET points=$1 WHERE id=$2`, pts, id)
+	return err
+}
+
+func SetSubmissionOverridePoints(id int, pts *float64) error {
+	_, err := DB.Exec(`UPDATE submissions SET override_points=$1 WHERE id=$2`, pts, id)
+	return err
 }

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -69,6 +69,9 @@ CREATE TABLE IF NOT EXISTS submissions (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+ALTER TABLE submissions ADD COLUMN IF NOT EXISTS points NUMERIC;
+ALTER TABLE submissions ADD COLUMN IF NOT EXISTS override_points NUMERIC;
+
 DO $$ BEGIN
     CREATE TYPE result_status AS ENUM ('passed','time_limit_exceeded','memory_limit_exceeded','wrong_output','runtime_error');
 EXCEPTION


### PR DESCRIPTION
## Summary
- add `points` and `override_points` fields to submissions schema
- track points earned in `Submission` model
- compute points in the grading worker and zero them when late
- allow teachers/admins to override points through a new endpoint

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867dff6ad98832186fdbe4737603a0f