### PR TITLE
Hide progress option for students

### DIFF
--- a/frontend/src/lib/Sidebar.svelte
+++ b/frontend/src/lib/Sidebar.svelte
@@ -4,6 +4,7 @@
   import { page } from '$app/stores';
   import '@fortawesome/fontawesome-free/css/all.min.css';
   import { sidebarOpen } from '$lib/sidebar';
+  import { auth } from '$lib/auth';
   let classes:any[] = [];
   let err = '';
   onMount(async () => {
@@ -37,8 +38,10 @@
             {c.name}
           </summary>
           <ul>
-            <li><a class={$page.url.pathname===`/classes/${c.id}` ? 'active' : ''} href={`/classes/${c.id}`} on:click={() => sidebarOpen.set(false)}>Overview</a></li>
-            <li><a class={$page.url.pathname===`/classes/${c.id}/progress` ? 'active' : ''} href={`/classes/${c.id}/progress`} on:click={() => sidebarOpen.set(false)}>Progress</a></li>
+            <li><a class={$page.url.pathname===`/classes/${c.id}` ? 'active' : ''} href={`/classes/${c.id}`} on:click={() => sidebarOpen.set(false)}>Assignments</a></li>
+            {#if $auth?.role !== 'student'}
+              <li><a class={$page.url.pathname===`/classes/${c.id}/progress` ? 'active' : ''} href={`/classes/${c.id}/progress`} on:click={() => sidebarOpen.set(false)}>Progress</a></li>
+            {/if}
           </ul>
         </details>
       </li>


### PR DESCRIPTION
## Summary
- rename "Overview" link to "Assignments"
- hide the "Progress" sidebar link unless user is not a student

## Testing
- `go test ./...`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6874dbd93e90832198dcb07ba2d9e8a1