### PR TITLE
Add basic Notes system

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -111,12 +111,20 @@ func main() {
 		api.DELETE("/users/:id", RoleGuard("admin"), deleteUser)
 		// List my submissions (student)
 		api.GET("/my-submissions", RoleGuard("student"), listSubs)
-                api.GET("/events", RoleGuard("student", "teacher", "admin"), eventsHandler)
-                api.DELETE("/classes/:id/students/:sid", RoleGuard("teacher", "admin"), removeStudent)
+		api.GET("/events", RoleGuard("student", "teacher", "admin"), eventsHandler)
+		api.DELETE("/classes/:id/students/:sid", RoleGuard("teacher", "admin"), removeStudent)
 
-                api.GET("/students", RoleGuard("teacher", "admin"), listStudents)
-                api.GET("/classes/:id/progress", RoleGuard("teacher", "admin"), getClassProgress)
-                api.GET("/classes/:id", RoleGuard("teacher", "student", "admin"), getClass)
+		api.GET("/students", RoleGuard("teacher", "admin"), listStudents)
+		api.GET("/classes/:id/progress", RoleGuard("teacher", "admin"), getClassProgress)
+		api.GET("/classes/:id", RoleGuard("teacher", "student", "admin"), getClass)
+
+		// Notes
+		api.GET("/classes/:id/notes", RoleGuard("student", "teacher", "admin"), listNotes)
+		api.POST("/classes/:id/notes", RoleGuard("teacher", "admin"), createNote)
+		api.GET("/notes/:id", RoleGuard("student", "teacher", "admin"), getNote)
+		api.PUT("/notes/:id", RoleGuard("teacher", "admin"), updateNote)
+		api.DELETE("/notes/:id", RoleGuard("teacher", "admin"), deleteNote)
+		api.PUT("/notes/:id/publish", RoleGuard("teacher", "admin"), publishNote)
 
 	}
 

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -97,3 +97,14 @@ CREATE TABLE IF NOT EXISTS class_students (
   student_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   PRIMARY KEY (class_id, student_id)
 );
+
+CREATE TABLE IF NOT EXISTS notes (
+  id SERIAL PRIMARY KEY,
+  class_id INTEGER NOT NULL REFERENCES classes(id) ON DELETE CASCADE,
+  path TEXT NOT NULL,
+  content TEXT NOT NULL,
+  published BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+

--- a/frontend/src/lib/Sidebar.svelte
+++ b/frontend/src/lib/Sidebar.svelte
@@ -39,6 +39,7 @@
           </summary>
           <ul>
             <li><a class={$page.url.pathname===`/classes/${c.id}` ? 'active' : ''} href={`/classes/${c.id}`} on:click={() => sidebarOpen.set(false)}>Assignments</a></li>
+            <li><a class={$page.url.pathname===`/classes/${c.id}/notes` ? 'active' : ''} href={`/classes/${c.id}/notes`} on:click={() => sidebarOpen.set(false)}>Notes</a></li>
             {#if $auth?.role === 'student'}
               <li><a class={$page.url.pathname===`/classes/${c.id}/overview` ? 'active' : ''} href={`/classes/${c.id}/overview`} on:click={() => sidebarOpen.set(false)}>Overview</a></li>
             {:else}

--- a/frontend/src/routes/classes/[id]/notes/+page.svelte
+++ b/frontend/src/routes/classes/[id]/notes/+page.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { apiFetch, apiJSON } from '$lib/api';
+import { page } from '$app/stores';
+import { auth } from '$lib/auth';
+import { get } from 'svelte/store';
+
+let id = $page.params.id;
+$: if ($page.params.id !== id) { id = $page.params.id; load(); }
+const role: string = get(auth)?.role ?? '';
+
+let notes:any[] = [];
+let loading = true;
+let err='';
+let path='';
+let content='';
+let createDialog: HTMLDialogElement;
+
+async function load(){
+  loading=true; err='';
+  try{ notes = await apiJSON(`/api/classes/${id}/notes`); }catch(e:any){err=e.message}
+  loading=false;
+}
+
+async function createNote(){
+  try{
+    await apiFetch(`/api/classes/${id}/notes`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({path,content})});
+    path=''; content='';
+    createDialog.close();
+    await load();
+  }catch(e:any){ err=e.message }
+}
+
+onMount(load);
+</script>
+
+<h1 class="text-2xl font-bold mb-4">Notes</h1>
+{#if loading}
+  <p>Loading…</p>
+{:else if err}
+  <p class="text-error">{err}</p>
+{:else}
+  <ul class="space-y-2">
+    {#each notes as n}
+      <li><a class="link" href={`/notes/${n.id}`}>{n.path}{!n.published ? ' (unpublished)' : ''}</a></li>
+    {/each}
+    {#if !notes.length}<li><i>No notes</i></li>{/if}
+  </ul>
+{/if}
+
+{#if role==='teacher' || role==='admin'}
+  <button class="btn mt-4" on:click={()=>createDialog.showModal()}>New note</button>
+  <dialog bind:this={createDialog} class="modal">
+    <div class="modal-box">
+      <h3 class="font-bold text-lg mb-4">Create note</h3>
+      <input class="input input-bordered w-full mb-2" placeholder="Path" bind:value={path}>
+      <textarea class="textarea textarea-bordered w-full h-40 mb-2" bind:value={content}></textarea>
+      <div class="modal-action">
+        <button class="btn" on:click={createNote}>Save</button>
+      </div>
+    </div>
+    <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  </dialog>
+{/if}

--- a/frontend/src/routes/notes/[id]/+page.svelte
+++ b/frontend/src/routes/notes/[id]/+page.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { apiJSON, apiFetch } from '$lib/api';
+import { page } from '$app/stores';
+import { auth } from '$lib/auth';
+import { get } from 'svelte/store';
+
+let id = $page.params.id;
+$: if ($page.params.id !== id){ id = $page.params.id; load(); }
+const role: string = get(auth)?.role ?? '';
+
+let note:any = null;
+let loading=true;
+let err='';
+
+async function load(){
+  loading=true; err='';
+  try{ note = await apiJSON(`/api/notes/${id}`); }catch(e:any){err=e.message}
+  loading=false;
+}
+
+async function publish(){
+  try{ await apiFetch(`/api/notes/${id}/publish`,{method:'PUT'}); await load(); }catch(e:any){err=e.message}
+}
+
+onMount(load);
+</script>
+
+{#if loading}
+<p>Loading…</p>
+{:else if err}
+<p class="text-error">{err}</p>
+{:else}
+<h1 class="text-2xl font-bold mb-4">{note.path}</h1>
+<pre class="whitespace-pre-wrap">{note.content}</pre>
+{#if (role==='teacher' || role==='admin') && !note.published}
+  <button class="btn mt-4" on:click={publish}>Publish</button>
+{/if}
+{/if}


### PR DESCRIPTION
## Summary
- store notes in new `notes` table
- Go endpoints for listing and managing notes
- link Notes in class sidebar
- Svelte pages to list and view notes

## Testing
- `go test ./...`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687503f36098832190bd27c29196c14a