### PR TITLE
Fix CodeMirror init by adding new NotebookEditor

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^6.7.2",
 				"@tailwindcss/vite": "^4.1.11",
+				"codemirror": "^5.65.19",
 				"daisyui": "^5.0.43",
 				"dompurify": "^3.2.6",
 				"easymde": "^2.20.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,10 +31,11 @@
 		"daisyui": "^5.0.43",
 		"dompurify": "^3.2.6",
 		"easymde": "^2.20.0",
-		"highlight.js": "^11.11.1",
-		"jszip": "^3.10.1",
-		"jwt-decode": "^4.0.0",
-		"marked": "^16.0.0",
-		"tailwindcss": "^4.1.11"
-	}
+                "highlight.js": "^11.11.1",
+                "jszip": "^3.10.1",
+                "jwt-decode": "^4.0.0",
+                "marked": "^16.0.0",
+                "tailwindcss": "^4.1.11",
+                "codemirror": "^5.65.19"
+        }
 }

--- a/frontend/src/lib/NotebookEditor.svelte
+++ b/frontend/src/lib/NotebookEditor.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { onMount, onDestroy, createEventDispatcher } from 'svelte';
+
+  export let value = '';
+  export let placeholder = '';
+  export let options: any = {};
+
+  let textarea: HTMLTextAreaElement;
+  let editor: any;
+  const dispatch = createEventDispatcher();
+
+  onMount(async () => {
+    const CodeMirror = (await import('codemirror')).default;
+    // expose global for addons expecting window.CodeMirror
+    (window as any).CodeMirror = CodeMirror;
+
+    await Promise.all([
+      import('codemirror/lib/codemirror.css'),
+      import('codemirror/mode/python/python'),
+      import('codemirror/addon/edit/closebrackets'),
+      import('codemirror/theme/base16-dark.css')
+    ]);
+
+    editor = CodeMirror.fromTextArea(textarea, {
+      value,
+      lineNumbers: true,
+      mode: 'python',
+      theme: 'base16-dark',
+      autoCloseBrackets: true,
+      ...options
+    });
+
+    editor.on('change', () => {
+      value = editor.getValue();
+      dispatch('input', value);
+    });
+  });
+
+  onDestroy(() => {
+    editor?.toTextArea();
+    editor = null;
+  });
+
+  $: if (editor && editor.getValue() !== value) {
+    editor.setValue(value);
+  }
+</script>
+
+<textarea bind:this={textarea} {placeholder}></textarea>
+
+<style>
+  textarea {
+    visibility: hidden;
+  }
+  .CodeMirror {
+    height: auto;
+  }
+</style>

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -2,3 +2,4 @@
 export { default as MarkdownEditor } from './MarkdownEditor.svelte';
 export { default as FileTree } from './FileTree.svelte';
 export { default as AdminPanel } from './AdminPanel.svelte';
+export { default as NotebookEditor } from './NotebookEditor.svelte';


### PR DESCRIPTION
## Summary
- add a NotebookEditor.svelte component that loads CodeMirror directly
- export NotebookEditor from the library index
- include codemirror as a dependency

## Testing
- `npm run build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687a7dda745c83218d8c5a8c86055eaf