### PR TITLE
Improve breadcrumb UI

### DIFF
--- a/frontend/src/routes/classes/[id]/files/+page.svelte
+++ b/frontend/src/routes/classes/[id]/files/+page.svelte
@@ -11,7 +11,7 @@ $: if ($page.params.id !== id) { id = $page.params.id; load(currentParent); }
 const role: string = get(auth)?.role ?? '';
 
 let items:any[] = [];
-let breadcrumbs:{id:number|null,name:string}[] = [{id:null,name:'/'}];
+let breadcrumbs:{id:number|null,name:string}[] = [{id:null,name:'🏠'}];
 let currentParent:number|null = null;
 let loading = false;
 let err = '';
@@ -107,7 +107,7 @@ onMount(()=>load(null));
 <nav class="mb-4 sticky top-16 z-40 bg-base-200 rounded-box shadow px-4 py-2">
   <ul class="flex flex-wrap gap-1 text-sm items-center">
     {#each breadcrumbs as b,i}
-      <li class="after:mx-1 after:content-['/'] last:after:hidden first:after:content-none">
+      <li class="after:mx-1 after:content-['/'] last:after:hidden">
         <a
           href="#"
           class="link px-2 py-1 rounded hover:bg-base-300"

--- a/frontend/src/routes/classes/[id]/files/+page.svelte
+++ b/frontend/src/routes/classes/[id]/files/+page.svelte
@@ -104,11 +104,16 @@ onMount(()=>load(null));
 </script>
 
 <h1 class="text-2xl font-bold mb-4">Files</h1>
-<nav class="mb-4">
+<nav class="mb-4 sticky top-16 z-40 bg-base-200 rounded-box shadow px-4 py-2">
   <ul class="flex flex-wrap gap-1 text-sm items-center">
     {#each breadcrumbs as b,i}
       <li class="after:mx-1 after:content-['/'] last:after:hidden first:after:content-none">
-        <a href="#" class="link" on:click|preventDefault={() => crumbTo(i)}>{b.name}</a>
+        <a
+          href="#"
+          class="link px-2 py-1 rounded hover:bg-base-300"
+          on:click|preventDefault={() => crumbTo(i)}
+          >{b.name}</a
+        >
       </li>
     {/each}
   </ul>


### PR DESCRIPTION
## Summary
- restyle file browser breadcrumbs as a sticky top bar

## Testing
- `go test ./...`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687cc3b8865c8321809f1abfdc1b0867