### PR TITLE
Fix notebook viewer

### DIFF
--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -56,6 +56,10 @@
   $: if (editor && value !== editor.value()) {
     editor.value(value);
   }
+
+  export function focus() {
+    textarea?.focus();
+  }
 </script>
 
 <textarea bind:this={textarea} class={className}></textarea>

--- a/frontend/src/lib/components/cells/MarkdownCell.svelte
+++ b/frontend/src/lib/components/cells/MarkdownCell.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { marked } from "marked";
   import { tick } from 'svelte';
-  import MarkdownEditor from '$lib/MarkdownEditor.svelte';
   import {
     notebookStore,
     moveCellUp,
@@ -16,9 +15,9 @@
 
   let editing = !cell.source;
 
-  let editorRef: MarkdownEditor;
+  let textarea: HTMLTextAreaElement;
 
-  // keep a local string bound to editor
+  // keep a local string bound to textarea
   let sourceStr = Array.isArray(cell.source) ? cell.source.join("") : (cell.source ?? "");
 
   $: {
@@ -30,14 +29,18 @@
   async function toggle() {
     editing = !editing;
     if (editing) {
+      sourceStr = Array.isArray(cell.source)
+        ? cell.source.join("")
+        : (cell.source ?? "");
       await tick();
-      // focus editor if possible
-      try { (editorRef as any)?.focus?.(); } catch {}
+      textarea?.focus();
     }
   }
 
-  function onInput(e?: CustomEvent) {
-    if (e && 'detail' in e) sourceStr = e.detail;
+  function onInput(e?: Event) {
+    if (e && e.target instanceof HTMLTextAreaElement) {
+      sourceStr = e.target.value;
+    }
     cell.source = sourceStr;
     // trigger store update so parent re-renders
     notebookStore.update((n) => n ? ({ ...n }) : n);
@@ -132,12 +135,13 @@
     </div>
   </div>
   {#if editing}
-    <MarkdownEditor
-      bind:this={editorRef}
+    <textarea
+      bind:this={textarea}
+      class="w-full bg-gray-100 p-2 rounded"
+      rows="4"
       bind:value={sourceStr}
-      className="w-full"
       on:input={onInput}
-    />
+    ></textarea>
     <button
       class="text-blue-600 mt-2 p-1 rounded hover:text-white hover:bg-gray-600 hover:scale-110 transition-transform"
       on:click={toggle}

--- a/frontend/src/lib/components/cells/MarkdownCell.svelte
+++ b/frontend/src/lib/components/cells/MarkdownCell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { marked } from "marked";
   import { tick } from 'svelte';
+  import MarkdownEditor from '$lib/MarkdownEditor.svelte';
   import {
     notebookStore,
     moveCellUp,
@@ -15,9 +16,9 @@
 
   let editing = !cell.source;
 
-  let textarea: HTMLTextAreaElement;
+  let editorRef: MarkdownEditor;
 
-  // keep a local string bound to textarea
+  // keep a local string bound to editor
   let sourceStr = Array.isArray(cell.source) ? cell.source.join("") : (cell.source ?? "");
 
   $: {
@@ -30,7 +31,8 @@
     editing = !editing;
     if (editing) {
       await tick();
-      textarea?.focus();
+      // focus editor if possible
+      try { (editorRef as any)?.focus?.(); } catch {}
     }
   }
 
@@ -129,13 +131,12 @@
     </div>
   </div>
   {#if editing}
-    <textarea
-      bind:this={textarea}
-      class="w-full bg-gray-100 p-2 rounded"
-      rows="4"
+    <MarkdownEditor
+      bind:this={editorRef}
       bind:value={sourceStr}
+      className="w-full"
       on:input={onInput}
-    ></textarea>
+    />
     <button
       class="text-blue-600 mt-2 p-1 rounded hover:text-white hover:bg-gray-600 hover:scale-110 transition-transform"
       on:click={toggle}

--- a/frontend/src/lib/components/cells/MarkdownCell.svelte
+++ b/frontend/src/lib/components/cells/MarkdownCell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { marked } from "marked";
   import { tick } from 'svelte';
+  import { MarkdownEditor } from '$lib';
   import {
     notebookStore,
     moveCellUp,
@@ -15,9 +16,9 @@
 
   let editing = !cell.source;
 
-  let textarea: HTMLTextAreaElement;
+  let editorRef: any;
 
-  // keep a local string bound to textarea
+  // keep a local string bound to the editor
   let sourceStr = Array.isArray(cell.source) ? cell.source.join("") : (cell.source ?? "");
 
   $: {
@@ -33,14 +34,11 @@
         ? cell.source.join("")
         : (cell.source ?? "");
       await tick();
-      textarea?.focus();
+      editorRef?.focus?.();
     }
   }
 
-  function onInput(e?: Event) {
-    if (e && e.target instanceof HTMLTextAreaElement) {
-      sourceStr = e.target.value;
-    }
+  function onInput() {
     cell.source = sourceStr;
     // trigger store update so parent re-renders
     notebookStore.update((n) => n ? ({ ...n }) : n);
@@ -135,13 +133,12 @@
     </div>
   </div>
   {#if editing}
-    <textarea
-      bind:this={textarea}
-      class="w-full bg-gray-100 p-2 rounded"
-      rows="4"
+    <MarkdownEditor
+      bind:this={editorRef}
       bind:value={sourceStr}
+      className="w-full bg-gray-100 p-2 rounded"
       on:input={onInput}
-    ></textarea>
+    />
     <button
       class="text-blue-600 mt-2 p-1 rounded hover:text-white hover:bg-gray-600 hover:scale-110 transition-transform"
       on:click={toggle}

--- a/frontend/src/lib/components/cells/MarkdownCell.svelte
+++ b/frontend/src/lib/components/cells/MarkdownCell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { marked } from "marked";
+  import { tick } from 'svelte';
   import {
     notebookStore,
     moveCellUp,
@@ -14,6 +15,8 @@
 
   let editing = !cell.source;
 
+  let textarea: HTMLTextAreaElement;
+
   // keep a local string bound to textarea
   let sourceStr = Array.isArray(cell.source) ? cell.source.join("") : (cell.source ?? "");
 
@@ -23,8 +26,12 @@
     if (s !== sourceStr) sourceStr = s;
   }
 
-  function toggle() {
+  async function toggle() {
     editing = !editing;
+    if (editing) {
+      await tick();
+      textarea?.focus();
+    }
   }
 
   function onInput() {
@@ -69,6 +76,18 @@
         <path d="M6 7h12M9 7v10m6-10v10M4 7h16l-1 12a2 2 0 01-2 2H7a2 2 0 01-2-2L4 7zM10 4h4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
       </svg>
     </button>
+    {#if !editing}
+      <button
+        aria-label="Edit cell"
+        title="Edit cell"
+        on:click={toggle}
+        class="p-1 rounded text-gray-600 hover:text-white hover:bg-gray-600 hover:scale-110 transition-transform"
+      >
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M4 17.25V21h3.75L17.81 10.94l-3.75-3.75L4 17.25zM20.71 7.04a1.003 1.003 0 0 0 0-1.42l-2.34-2.34a1.003 1.003 0 0 0-1.42 0l-1.83 1.83 3.75 3.75 1.84-1.82z" />
+        </svg>
+      </button>
+    {/if}
     <div class="relative">
       <button
         aria-label="Insert cell"
@@ -111,6 +130,7 @@
   </div>
   {#if editing}
     <textarea
+      bind:this={textarea}
       class="w-full bg-gray-100 p-2 rounded"
       rows="4"
       bind:value={sourceStr}
@@ -121,7 +141,7 @@
       on:click={toggle}
     >Preview</button>
   {:else}
-  <div class="prose">
+  <div class="markdown">
     {@html marked.parse(sourceStr)}
     </div>
   {/if}

--- a/frontend/src/lib/components/cells/MarkdownCell.svelte
+++ b/frontend/src/lib/components/cells/MarkdownCell.svelte
@@ -36,7 +36,8 @@
     }
   }
 
-  function onInput() {
+  function onInput(e?: CustomEvent) {
+    if (e && 'detail' in e) sourceStr = e.detail;
     cell.source = sourceStr;
     // trigger store update so parent re-renders
     notebookStore.update((n) => n ? ({ ...n }) : n);

--- a/frontend/src/lib/components/cells/OutputBlock.svelte
+++ b/frontend/src/lib/components/cells/OutputBlock.svelte
@@ -2,13 +2,22 @@
 <script lang="ts">
   export let label: 'stdout' | 'stderr' | 'result';
   export let text = '';
-  const colors = {
-    stdout: 'emerald',
-    stderr: 'rose',
-    result: 'slate'
-  }[label];
+  const stdout = label === 'stdout';
+  const stderr = label === 'stderr';
+  const result = label === 'result';
 </script>
 
 {#if text}
-  <pre class={`my-1 rounded-md bg-${colors}-50 text-${colors}-800 border-l-4 border-${colors}-400 font-mono whitespace-pre-wrap p-1 px-2`}>{text}</pre>
+  <pre
+    class="my-1 rounded-md font-mono whitespace-pre-wrap p-1 px-2 border-l-4"
+    class:bg-emerald-50={stdout}
+    class:text-emerald-800={stdout}
+    class:border-emerald-400={stdout}
+    class:bg-rose-50={stderr}
+    class:text-rose-800={stderr}
+    class:border-rose-400={stderr}
+    class:bg-slate-50={result}
+    class:text-slate-800={result}
+    class:border-slate-400={result}
+  >{text}</pre>
 {/if}


### PR DESCRIPTION
## Summary
- add Edit button and autofocus to markdown cells
- use `.markdown` class so markdown preview is styled properly
- use Tailwind `class:` directives in outputs so stdout/stderr/result look different

## Testing
- `go test ./...`
- `npm run check` *(fails: svelte-check found 9 errors and 25 warnings)*
- `npm run build` *(fails: worker.format not supported)*

------
https://chatgpt.com/codex/tasks/task_e_687cd54eba4483219acbfb99f1d9efca