### PR TITLE
Fix preview mode cleanup in Markdown editor

### DIFF
--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -49,12 +49,16 @@
   });
 
   export function destroyEditor() {
-    if (editor) {
+    if (!editor) return;
+    try {
       // EasyMDE leaves additional DOM when destroyed from preview mode
       if (typeof editor.isPreviewActive === 'function' && editor.isPreviewActive()) {
         editor.togglePreview();
       }
       editor.toTextArea();
+    } catch (err) {
+      console.warn('Failed to destroy editor', err);
+    } finally {
       editor = null;
     }
   }

--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -48,7 +48,7 @@
     });
   });
 
-  onDestroy(() => {
+  export function destroyEditor() {
     if (editor) {
       // EasyMDE leaves additional DOM when destroyed from preview mode
       if (typeof editor.isPreviewActive === 'function' && editor.isPreviewActive()) {
@@ -57,6 +57,10 @@
       editor.toTextArea();
       editor = null;
     }
+  }
+
+  onDestroy(() => {
+    destroyEditor();
   });
 
   $: if (editor && value !== editor.value()) {

--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -49,8 +49,14 @@
   });
 
   onDestroy(() => {
-    editor?.toTextArea();
-    editor = null;
+    if (editor) {
+      // EasyMDE leaves additional DOM when destroyed from preview mode
+      if (typeof editor.isPreviewActive === 'function' && editor.isPreviewActive()) {
+        editor.togglePreview();
+      }
+      editor.toTextArea();
+      editor = null;
+    }
   });
 
   $: if (editor && value !== editor.value()) {

--- a/frontend/src/lib/components/cells/MarkdownCell.svelte
+++ b/frontend/src/lib/components/cells/MarkdownCell.svelte
@@ -28,6 +28,10 @@
   }
 
   async function toggle() {
+    if (editing) {
+      // clean up the EasyMDE instance before the component unmounts
+      editorRef?.destroyEditor?.();
+    }
     editing = !editing;
     if (editing) {
       sourceStr = Array.isArray(cell.source)


### PR DESCRIPTION
## Summary
- prevent EasyMDE preview mode from breaking markdown cell editing

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687ce5799d648321a55e7efee9b2847d