### PR TITLE
Remove footer copyright

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -67,10 +67,5 @@
       <slot />
     </main>
 
-    <footer class="footer footer-center p-4 bg-base-200 text-base-content">
-      <aside>
-        <p>© 2025 CodeGrader</p>
-      </aside>
-    </footer>
   </div>
 


### PR DESCRIPTION
## Summary
- remove bottom copyright text from layout

## Testing
- `go test ./...`
- `npm run check` *(fails: svelte-check found 9 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687cf5b40ba48321825def0455f512e4