### PR TITLE
Add collapsible sidebar and integrate with Markdown editor

### DIFF
--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { createEventDispatcher } from 'svelte';
+  import { sidebarCollapsed, sidebarOpen } from '$lib/sidebar';
   import '@fortawesome/fontawesome-free/css/all.min.css';
 
   let EasyMDE: any;
@@ -45,6 +46,25 @@
     editor.codemirror.on('change', () => {
       value = editor!.value();
       dispatch('input', value);
+    });
+
+    const updateSidebar = () => {
+      if (editor?.isSideBySideActive && editor.isSideBySideActive()) {
+        sidebarCollapsed.set(true);
+        sidebarOpen.set(false);
+      } else {
+        sidebarCollapsed.set(false);
+      }
+    };
+    const btn = editor.toolbarElements?.['side-by-side'];
+    btn?.addEventListener('click', updateSidebar);
+    const preview = editor.codemirror.getWrapperElement().nextSibling;
+    const observer = new MutationObserver(updateSidebar);
+    observer.observe(preview, { attributes: true, attributeFilter: ['class'] });
+    updateSidebar();
+    onDestroy(() => {
+      btn?.removeEventListener('click', updateSidebar);
+      observer.disconnect();
     });
   });
 

--- a/frontend/src/lib/Sidebar.svelte
+++ b/frontend/src/lib/Sidebar.svelte
@@ -3,7 +3,7 @@
   import { apiJSON } from '$lib/api';
   import { page } from '$app/stores';
   import '@fortawesome/fontawesome-free/css/all.min.css';
-  import { sidebarOpen } from '$lib/sidebar';
+  import { sidebarOpen, sidebarCollapsed } from '$lib/sidebar';
   import { auth } from '$lib/auth';
   let classes:any[] = [];
   let err = '';
@@ -17,7 +17,7 @@
 <aside
   class={`fixed top-0 left-0 z-40 w-60 bg-base-200 p-4 h-screen overflow-y-auto transition-transform
       ${$sidebarOpen ? 'block translate-x-0' : 'hidden -translate-x-full'}
-      sm:block sm:translate-x-0`}
+      sm:block ${$sidebarCollapsed ? '-translate-x-full' : 'translate-x-0'}`}
 >
   <button
     class="btn btn-square btn-ghost absolute right-2 top-2 sm:hidden"

--- a/frontend/src/lib/sidebar.ts
+++ b/frontend/src/lib/sidebar.ts
@@ -2,3 +2,6 @@ import { writable } from 'svelte/store';
 
 /** controls whether the sidebar is open on small screens */
 export const sidebarOpen = writable(false);
+
+/** controls whether the sidebar is collapsed on large screens */
+export const sidebarCollapsed = writable(false);

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
   import { onMount } from 'svelte';
   import '../app.css';
   import Sidebar from '$lib/Sidebar.svelte';
-  import { sidebarOpen } from '$lib/sidebar';
+  import { sidebarOpen, sidebarCollapsed } from '$lib/sidebar';
 
   function logout() {
     auth.logout();
@@ -22,10 +22,25 @@
     <Sidebar />
   {/if}
 
-  <div class={`min-h-screen flex flex-col ${user ? 'sm:ml-60' : ''}`}>
+  <div class={`min-h-screen flex flex-col ${user && !$sidebarCollapsed ? 'sm:ml-60' : ''}`}>
     <div class="navbar bg-base-200 shadow sticky top-0 z-50">
       <div class="flex-1">
         {#if user}
+          <button
+            class="btn btn-square btn-ghost mr-2 hidden sm:inline-flex"
+            on:click={() => sidebarCollapsed.update(v => !v)}
+            aria-label="Toggle sidebar"
+          >
+            {#if $sidebarCollapsed}
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+                <path d="M9.75 5.25L16.5 12l-6.75 6.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            {:else}
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+                <path d="M14.25 5.25L7.5 12l6.75 6.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            {/if}
+          </button>
           <button
             class="btn btn-square btn-ghost mr-2 sm:hidden"
             on:click={() => sidebarOpen.update((v) => !v)}


### PR DESCRIPTION
## Summary
- let users collapse the sidebar
- show toggle button in the navbar
- automatically collapse sidebar when Markdown editor enters side-by-side mode
- expand sidebar again when side-by-side mode is exited

## Testing
- `go test ./...`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687cf57e990c83218239a2c1f99eb00c