### PR TITLE
Implement notebook saving for teachers

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -123,6 +123,7 @@ func main() {
 		api.POST("/classes/:id/files", RoleGuard("teacher", "admin"), uploadClassFile)
 		api.GET("/files/:id", RoleGuard("teacher", "student", "admin"), downloadClassFile)
 		api.PUT("/files/:id", RoleGuard("teacher", "admin"), renameClassFile)
+		api.PUT("/files/:id/content", RoleGuard("teacher", "admin"), updateFileContent)
 		api.DELETE("/files/:id", RoleGuard("teacher", "admin"), deleteClassFile)
 
 	}

--- a/backend/models.go
+++ b/backend/models.go
@@ -816,6 +816,11 @@ func DeleteFile(id int) error {
 	return err
 }
 
+func UpdateFileContent(id int, data []byte) error {
+	_, err := DB.Exec(`UPDATE class_files SET content=$1, size=$2, updated_at=now() WHERE id=$3`, data, len(data), id)
+	return err
+}
+
 func IsTeacherOfClass(cid, teacherID int) (bool, error) {
 	var x int
 	err := DB.Get(&x, `SELECT 1 FROM classes WHERE id=$1 AND teacher_id=$2`, cid, teacherID)

--- a/frontend/src/lib/components/NotebookEditor.svelte
+++ b/frontend/src/lib/components/NotebookEditor.svelte
@@ -33,6 +33,9 @@
   }
 
   async function saveNotebook() {
+    // run all cells so outputs are included in the saved notebook
+    await runAllCells();
+
     const json = serializeNotebook(nb);
     if (fileId && $auth?.role === 'teacher') {
       await apiFetch(`/api/files/${fileId}/content`, {
@@ -40,6 +43,7 @@
         headers: { 'Content-Type': 'application/json' },
         body: json
       });
+      alert('Saved!');
     } else {
       const blob = new Blob([json], { type: 'application/json' });
       saveAs(blob, 'notebook.ipynb');

--- a/frontend/src/lib/components/NotebookEditor.svelte
+++ b/frontend/src/lib/components/NotebookEditor.svelte
@@ -6,6 +6,10 @@
   import MarkdownCell from "./cells/MarkdownCell.svelte";
   import { v4 as uuid } from "uuid";
   import { serializeNotebook } from "$lib/notebook";
+  import { apiFetch } from "$lib/api";
+  import { auth } from "$lib/auth";
+
+  export let fileId: string | number | undefined;
   $: nb = $notebookStore;
 
   let cellRefs: any[] = [];
@@ -28,10 +32,18 @@
 
   }
 
-  function saveNotebook() {
+  async function saveNotebook() {
     const json = serializeNotebook(nb);
-    const blob = new Blob([json], { type: "application/json" });
-    saveAs(blob, "notebook.ipynb");
+    if (fileId && $auth?.role === 'teacher') {
+      await apiFetch(`/api/files/${fileId}/content`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: json
+      });
+    } else {
+      const blob = new Blob([json], { type: 'application/json' });
+      saveAs(blob, 'notebook.ipynb');
+    }
   }
 </script>
 
@@ -83,13 +95,15 @@
           <path d="M16 18l6-6-6-6M8 6L2 12l6 6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
       </button>
-      <button
-        on:click={saveNotebook}
-        aria-label="Save notebook"
-        class="px-3 py-1 rounded text-gray-600 hover:text-white hover:bg-gray-600 hover:scale-110 transition-transform"
-      >
-        Save
-      </button>
+      {#if $auth?.role === 'teacher' && fileId}
+        <button
+          on:click={saveNotebook}
+          aria-label="Save notebook"
+          class="px-3 py-1 rounded text-gray-600 hover:text-white hover:bg-gray-600 hover:scale-110 transition-transform"
+        >
+          Save
+        </button>
+      {/if}
     </div>
     <div class="flex justify-end">
       <button

--- a/frontend/src/routes/files/[id]/+page.svelte
+++ b/frontend/src/routes/files/[id]/+page.svelte
@@ -23,5 +23,5 @@
 </script>
 
 <h1 class="text-2xl font-bold mb-4">Notebook</h1>
-<NotebookEditor />
+<NotebookEditor fileId={id} />
 


### PR DESCRIPTION
## Summary
- add API endpoint to update class file content
- allow teachers to persist notebook files
- hide Save button for students

## Testing
- `npm run check`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687cf654080c8321b739ad58c59f9d27