### PR TITLE
Add image previews

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -1010,8 +1011,14 @@ func downloadClassFile(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "not a file"})
 		return
 	}
-	c.Writer.Header().Set("Content-Disposition", "attachment; filename="+strconv.Quote(f.Name))
-	c.Data(http.StatusOK, "application/octet-stream", f.Content)
+	ext := strings.ToLower(filepath.Ext(f.Name))
+	switch ext {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg":
+		c.Data(http.StatusOK, mime.TypeByExtension(ext), f.Content)
+	default:
+		c.Writer.Header().Set("Content-Disposition", "attachment; filename="+strconv.Quote(f.Name))
+		c.Data(http.StatusOK, "application/octet-stream", f.Content)
+	}
 }
 
 func renameClassFile(c *gin.Context) {

--- a/frontend/src/routes/classes/[id]/files/+page.svelte
+++ b/frontend/src/routes/classes/[id]/files/+page.svelte
@@ -119,7 +119,6 @@ async function rename(item:any){
 onMount(()=>load(null));
 </script>
 
-<h1 class="text-2xl font-bold mb-4">Files</h1>
 <nav class="mb-4 sticky top-16 z-40 bg-base-200 rounded-box shadow px-4 py-2 flex items-center justify-between flex-wrap gap-2">
   <ul class="flex flex-wrap gap-1 text-sm items-center">
     {#each breadcrumbs as b,i}

--- a/frontend/src/routes/classes/[id]/files/+page.svelte
+++ b/frontend/src/routes/classes/[id]/files/+page.svelte
@@ -17,6 +17,11 @@ let loading = false;
 let err = '';
 let uploadInput: HTMLInputElement;
 
+function isImage(name: string) {
+  const ext = name.split('.').pop()?.toLowerCase();
+  return ['png','jpg','jpeg','gif','webp','svg'].includes(ext ?? '');
+}
+
 function iconClass(name: string) {
   const ext = name.split('.').pop()?.toLowerCase();
   switch (ext) {
@@ -48,7 +53,7 @@ function iconClass(name: string) {
 
 function open(item: any) {
   if (item.is_dir) openDir(item);
-  else if (item.name.toLowerCase().endsWith('.ipynb'))
+  else if (item.name.toLowerCase().endsWith('.ipynb') || isImage(item.name))
     window.open(`/files/${item.id}`, '_blank');
   else window.open(`/api/files/${item.id}`, '_blank');
 }
@@ -152,6 +157,8 @@ onMount(()=>load(null));
       <div class="text-5xl mb-2">
         {#if it.is_dir}
           <i class="fa-solid fa-folder text-warning"></i>
+        {:else if isImage(it.name)}
+          <img src={`/api/files/${it.id}`} alt={it.name} class="w-16 h-16 object-cover rounded" />
         {:else}
           <i class="fa-solid {iconClass(it.name)}"></i>
         {/if}

--- a/frontend/src/routes/files/[id]/+page.svelte
+++ b/frontend/src/routes/files/[id]/+page.svelte
@@ -6,6 +6,12 @@
   import NotebookEditor from '$lib/components/NotebookEditor.svelte';
   import { apiFetch } from '$lib/api';
   import { onDestroy } from 'svelte';
+  import '@fortawesome/fontawesome-free/css/all.min.css';
+
+  function goBack() {
+    if (history.length > 1) history.back();
+    else window.close();
+  }
 
   let id = $page.params.id;
   $: if ($page.params.id !== id) {
@@ -42,6 +48,9 @@
   onMount(load);
 </script>
 
+<button class="btn btn-sm mb-4" on:click={goBack} aria-label="Back to files">
+  <i class="fa-solid fa-arrow-left"></i> Back
+</button>
 {#if isImage}
   <h1 class="text-2xl font-bold mb-4">Image</h1>
   {#if imgUrl}

--- a/frontend/src/routes/files/[id]/+page.svelte
+++ b/frontend/src/routes/files/[id]/+page.svelte
@@ -5,6 +5,7 @@
   import { loadNotebook } from '$lib/notebook';
   import NotebookEditor from '$lib/components/NotebookEditor.svelte';
   import { apiFetch } from '$lib/api';
+  import { onDestroy } from 'svelte';
 
   let id = $page.params.id;
   $: if ($page.params.id !== id) {
@@ -12,16 +13,42 @@
     load();
   }
 
+  let isImage = false;
+  let imgUrl: string | null = null;
+
   async function load() {
+    if (imgUrl) {
+      URL.revokeObjectURL(imgUrl);
+      imgUrl = null;
+    }
     const res = await apiFetch(`/api/files/${id}`);
-    const text = await res.text();
-    const nb = loadNotebook(text);
-    notebookStore.set(nb);
+    const ct = res.headers.get('Content-Type') || '';
+    if (ct.startsWith('image/')) {
+      const blob = await res.blob();
+      imgUrl = URL.createObjectURL(blob);
+      isImage = true;
+    } else {
+      const text = await res.text();
+      const nb = loadNotebook(text);
+      notebookStore.set(nb);
+      isImage = false;
+    }
   }
+
+  onDestroy(() => {
+    if (imgUrl) URL.revokeObjectURL(imgUrl);
+  });
 
   onMount(load);
 </script>
 
-<h1 class="text-2xl font-bold mb-4">Notebook</h1>
-<NotebookEditor fileId={id} />
+{#if isImage}
+  <h1 class="text-2xl font-bold mb-4">Image</h1>
+  {#if imgUrl}
+    <img src={imgUrl} alt="image" class="max-w-full" />
+  {/if}
+{:else}
+  <h1 class="text-2xl font-bold mb-4">Notebook</h1>
+  <NotebookEditor fileId={id} />
+{/if}
 

--- a/frontend/src/routes/files/[id]/+page.svelte
+++ b/frontend/src/routes/files/[id]/+page.svelte
@@ -52,12 +52,10 @@
   <i class="fa-solid fa-arrow-left"></i> Back
 </button>
 {#if isImage}
-  <h1 class="text-2xl font-bold mb-4">Image</h1>
   {#if imgUrl}
     <img src={imgUrl} alt="image" class="max-w-full" />
   {/if}
 {:else}
-  <h1 class="text-2xl font-bold mb-4">Notebook</h1>
   <NotebookEditor fileId={id} />
 {/if}
 


### PR DESCRIPTION
## Summary
- preview image files in file browser and open them in-app
- serve images without attachment headers

## Testing
- `npm run check` *(fails: svelte-check found 9 errors and 26 warnings)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687d01772f4c8321bb01c27300f5b554