### PR TITLE
Fix Files breadcrumb overlay on mobile

### DIFF
--- a/frontend/src/routes/classes/[id]/files/+page.svelte
+++ b/frontend/src/routes/classes/[id]/files/+page.svelte
@@ -146,7 +146,7 @@ async function rename(item:any){
 onMount(()=>load(null));
 </script>
 
-<nav class="mb-4 sticky top-16 z-40 bg-base-200 rounded-box shadow px-4 py-2 flex items-center justify-between flex-wrap gap-2">
+<nav class="mb-4 sticky top-16 z-30 bg-base-200 rounded-box shadow px-4 py-2 flex items-center justify-between flex-wrap gap-2">
   <ul class="flex flex-wrap gap-1 text-sm items-center">
     {#each breadcrumbs as b,i}
       <li class="after:mx-1 after:content-['/'] last:after:hidden">


### PR DESCRIPTION
## Summary
- reduce z-index on Files page breadcrumb so the sidebar overlays it on mobile

## Testing
- `npm run check` *(fails: svelte-check found errors)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687d0c898dfc8321a5ee045222325277