### PR TITLE
Use icon-only button for file viewer back navigation

### DIFF
--- a/frontend/src/routes/files/[id]/+page.svelte
+++ b/frontend/src/routes/files/[id]/+page.svelte
@@ -48,8 +48,8 @@
   onMount(load);
 </script>
 
-<button class="btn btn-sm mb-4" on:click={goBack} aria-label="Back to files">
-  <i class="fa-solid fa-arrow-left"></i> Back
+<button class="btn btn-sm btn-circle mb-4" on:click={goBack} aria-label="Back to files">
+  <i class="fa-solid fa-arrow-left"></i>
 </button>
 {#if isImage}
   {#if imgUrl}


### PR DESCRIPTION
## Summary
- make the "Back" control in the file view a small circular icon button

## Testing
- `go test ./...`
- `npm run check` *(fails: svelte-check found 9 errors and 27 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687d11cec5408321978680eb7a4cb0f1