### PR TITLE
Add notebooks listing tab

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -927,6 +927,32 @@ func listClassFiles(c *gin.Context) {
 	c.JSON(http.StatusOK, list)
 }
 
+func listClassNotebooks(c *gin.Context) {
+	cid, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	role := c.GetString("role")
+	if role == "teacher" {
+		if ok, err := IsTeacherOfClass(cid, c.GetInt("userID")); err != nil || !ok {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+	} else if role == "student" {
+		if ok, err := IsStudentOfClass(cid, c.GetInt("userID")); err != nil || !ok {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+	}
+	list, err := ListNotebooks(cid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}
+
 func uploadClassFile(c *gin.Context) {
 	cid, err := strconv.Atoi(c.Param("id"))
 	if err != nil {

--- a/backend/main.go
+++ b/backend/main.go
@@ -120,6 +120,7 @@ func main() {
 
 		// Class file system
 		api.GET("/classes/:id/files", RoleGuard("teacher", "student", "admin"), listClassFiles)
+		api.GET("/classes/:id/notebooks", RoleGuard("teacher", "student", "admin"), listClassNotebooks)
 		api.POST("/classes/:id/files", RoleGuard("teacher", "admin"), uploadClassFile)
 		api.GET("/files/:id", RoleGuard("teacher", "student", "admin"), downloadClassFile)
 		api.PUT("/files/:id", RoleGuard("teacher", "admin"), renameClassFile)

--- a/backend/models.go
+++ b/backend/models.go
@@ -748,6 +748,15 @@ func ListFiles(classID int, parentID *int) ([]ClassFile, error) {
 	return list, err
 }
 
+func ListNotebooks(classID int) ([]ClassFile, error) {
+	list := []ClassFile{}
+	err := DB.Select(&list, `SELECT id,class_id,parent_id,name,path,is_dir,size,created_at,updated_at
+                FROM class_files
+               WHERE class_id=$1 AND NOT is_dir AND lower(name) LIKE '%.ipynb'
+               ORDER BY updated_at DESC`, classID)
+	return list, err
+}
+
 func SaveFile(classID int, parentID *int, name string, data []byte, isDir bool) (*ClassFile, error) {
 	path, err := buildFilePath(parentID, name)
 	if err != nil {

--- a/frontend/src/lib/Sidebar.svelte
+++ b/frontend/src/lib/Sidebar.svelte
@@ -42,6 +42,7 @@
           <ul>
             <li><a class={$page.url.pathname===`/classes/${c.id}` ? 'active' : ''} href={`/classes/${c.id}`} on:click={() => sidebarOpen.set(false)}>Assignments</a></li>
             <li><a class={$page.url.pathname===`/classes/${c.id}/files` ? 'active' : ''} href={`/classes/${c.id}/files`} on:click={() => sidebarOpen.set(false)}>Files</a></li>
+            <li><a class={$page.url.pathname===`/classes/${c.id}/notes` ? 'active' : ''} href={`/classes/${c.id}/notes`} on:click={() => sidebarOpen.set(false)}>Notes</a></li>
             {#if $auth?.role === 'student'}
               <li><a class={$page.url.pathname===`/classes/${c.id}/overview` ? 'active' : ''} href={`/classes/${c.id}/overview`} on:click={() => sidebarOpen.set(false)}>Overview</a></li>
             {:else}

--- a/frontend/src/routes/classes/[id]/notes/+page.svelte
+++ b/frontend/src/routes/classes/[id]/notes/+page.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { apiJSON } from '$lib/api';
+import { page } from '$app/stores';
+
+let id = $page.params.id;
+$: if ($page.params.id !== id) { id = $page.params.id; load(); }
+
+let notes:any[] = [];
+let loading = true;
+let err = '';
+
+async function load(){
+  loading = true; err = '';
+  try {
+    notes = await apiJSON(`/api/classes/${id}/notebooks`);
+  } catch(e:any){ err = e.message; }
+  loading = false;
+}
+
+onMount(load);
+</script>
+
+<h1 class="text-2xl font-bold mb-4">Notes</h1>
+{#if loading}
+  <p>Loading…</p>
+{:else if err}
+  <p class="text-error">{err}</p>
+{:else}
+  <ul class="space-y-2">
+    {#each notes as n}
+      <li class="flex justify-between items-center">
+        <a class="link" href={`/files/${n.id}`}>{n.path}</a>
+        <span class="text-sm text-gray-500">{new Date(n.updated_at).toLocaleString()}</span>
+      </li>
+    {/each}
+    {#if !notes.length}
+      <li><i>No notes</i></li>
+    {/if}
+  </ul>
+{/if}
+

--- a/frontend/src/routes/classes/[id]/notes/+page.ts
+++ b/frontend/src/routes/classes/[id]/notes/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;


### PR DESCRIPTION
## Summary
- backend: support listing of notebooks per class
- add API handler and route for class notebooks
- sidebar: link to Notes tab for each class
- frontend: show notebook list in new Notes tab

## Testing
- `go test ./...`
- `npm run build` *(fails: Invalid value "iife" for option "worker.format" in pyodide)*

------
https://chatgpt.com/codex/tasks/task_e_687d11c26b788321adc40865c5977369