### PR TITLE
Add list view mode for file browser

### DIFF
--- a/frontend/src/routes/classes/[id]/files/+page.svelte
+++ b/frontend/src/routes/classes/[id]/files/+page.svelte
@@ -237,7 +237,9 @@ onMount(()=>load(null));
           <th>Name</th>
           <th>Size</th>
           <th>Modified</th>
-          {#if role==='teacher' || role==='admin'}<th></th>{/if}
+          {#if role==='teacher' || role==='admin'}
+            <th class="w-16"></th>
+          {/if}
         </tr>
       </thead>
       <tbody>
@@ -255,7 +257,7 @@ onMount(()=>load(null));
             <td class="text-right">{it.is_dir ? '' : it.size}</td>
             <td class="text-right">{new Date(it.updated_at).toLocaleString()}</td>
             {#if role==='teacher' || role==='admin'}
-              <td class="text-right whitespace-nowrap">
+              <td class="text-right whitespace-nowrap w-16">
                 <button class="btn btn-xs btn-circle invisible group-hover:visible" title="Rename" on:click|stopPropagation={() => rename(it)}>
                   <i class="fa-solid fa-pen"></i>
                 </button>
@@ -267,7 +269,9 @@ onMount(()=>load(null));
           </tr>
         {/each}
         {#if !items.length}
-          <tr><td colspan="4"><i>Empty</i></td></tr>
+          <tr>
+            <td colspan={role==='teacher' || role==='admin' ? 4 : 3}><i>Empty</i></td>
+          </tr>
         {/if}
       </tbody>
     </table>

--- a/frontend/src/routes/classes/[id]/files/+page.svelte
+++ b/frontend/src/routes/classes/[id]/files/+page.svelte
@@ -154,6 +154,19 @@ function toggleView() {
     localStorage.setItem('fileViewMode', viewMode);
   }
 }
+function fmtSize(bytes: number | null | undefined, decimals = 1) {
+  if (bytes == null) return '';
+  if (bytes < 1024) return `${bytes} B`;
+
+  const units = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  let i = -1;
+  do {
+    bytes /= 1024;
+    i++;
+  } while (bytes >= 1024 && i < units.length - 1);
+
+  return `${bytes.toFixed(decimals)} ${units[i]}`;
+}
 
 onMount(()=>load(null));
 </script>
@@ -234,9 +247,9 @@ onMount(()=>load(null));
     <table class="table table-zebra w-full">
       <thead>
         <tr>
-          <th>Name</th>
-          <th>Size</th>
-          <th>Modified</th>
+          <th class="text-left">Name</th>
+          <th class="text-right">Size</th>
+          <th class="text-right">Modified</th>
           {#if role==='teacher' || role==='admin'}
             <th class="w-16"></th>
           {/if}
@@ -254,7 +267,7 @@ onMount(()=>load(null));
                 <i class="fa-solid {iconClass(it.name)} mr-2"></i>{it.name}
               {/if}
             </td>
-            <td class="text-right">{it.is_dir ? '' : it.size}</td>
+            <td class="text-right">{it.is_dir ? '' : fmtSize(it.size)}</td>
             <td class="text-right">{new Date(it.updated_at).toLocaleString()}</td>
             {#if role==='teacher' || role==='admin'}
               <td class="text-right whitespace-nowrap w-16">


### PR DESCRIPTION
## Summary
- add view mode state to file browser and persist to `localStorage`
- allow toggling between grid and list views from breadcrumb bar
- render file listing in table when list mode is active

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687d1318f90483218c421801f056044f