### PR TITLE
Preload Pyodide kernel

### DIFF
--- a/frontend/src/lib/components/NotebookEditor.svelte
+++ b/frontend/src/lib/components/NotebookEditor.svelte
@@ -9,7 +9,7 @@ import { serializeNotebook } from "$lib/notebook";
 import { apiFetch } from "$lib/api";
 import { auth } from "$lib/auth";
 import { onMount, afterUpdate } from 'svelte';
-import { initPyodide } from '$lib/pyodide';
+import { preloadPyodide } from '$lib/pyodide';
 
   export let fileId: string | number | undefined;
   $: nb = $notebookStore;
@@ -25,10 +25,9 @@ import { initPyodide } from '$lib/pyodide';
   }
 
   onMount(() => {
-    // Preload the Pyodide runtime in the background so that executing
-    // the first cell is instantaneous. This does not block the main thread
-    // because the loading happens inside a Web Worker.
-    void initPyodide();
+    // Preload the Pyodide runtime and common packages in the background.
+    // Loading happens inside a Web Worker so it does not block the UI.
+    preloadPyodide();
     checkHeight();
     window.addEventListener('resize', checkHeight);
     return () => window.removeEventListener('resize', checkHeight);

--- a/frontend/src/lib/components/NotebookEditor.svelte
+++ b/frontend/src/lib/components/NotebookEditor.svelte
@@ -9,6 +9,7 @@ import { serializeNotebook } from "$lib/notebook";
 import { apiFetch } from "$lib/api";
 import { auth } from "$lib/auth";
 import { onMount, afterUpdate } from 'svelte';
+import { initPyodide } from '$lib/pyodide';
 
   export let fileId: string | number | undefined;
   $: nb = $notebookStore;
@@ -24,6 +25,10 @@ import { onMount, afterUpdate } from 'svelte';
   }
 
   onMount(() => {
+    // Preload the Pyodide runtime in the background so that executing
+    // the first cell is instantaneous. This does not block the main thread
+    // because the loading happens inside a Web Worker.
+    void initPyodide();
     checkHeight();
     window.addEventListener('resize', checkHeight);
     return () => window.removeEventListener('resize', checkHeight);

--- a/frontend/src/lib/pyWorker.ts
+++ b/frontend/src/lib/pyWorker.ts
@@ -28,7 +28,11 @@ plt.show = _silent_show
 }
 
 self.onmessage = async (e: MessageEvent) => {
-  const { id, type, code } = e.data as { id: number; type: string; code?: string };
+  const { id, type, code } = e.data as { id?: number; type: string; code?: string };
+  if (type === 'init') {
+    await ensurePyodide();
+    return;
+  }
   if (type === 'run') {
     await ensurePyodide();
     stdoutBuffer = [];


### PR DESCRIPTION
## Summary
- preload Pyodide runtime when opening notebooks to reduce first cell execution time

## Testing
- `go test ./...` in `backend`
- `npm run check` in `frontend` *(fails: svelte-check found 9 errors and 28 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687d23c0178c832186f93df34bf1ce77