### PR TITLE
Fix MarkdownEditor toolbar position

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -33,3 +33,15 @@
   padding: 0.2rem 0.4rem;
   border-radius: 4px;
 }
+
+/* Ensure the markdown editor toolbar stays visible below the sticky navbar */
+.editor-toolbar.fullscreen {
+  top: 4rem;
+}
+.editor-toolbar.fullscreen::before,
+.editor-toolbar.fullscreen::after {
+  top: 4rem;
+}
+.CodeMirror-fullscreen {
+  top: calc(4rem + 50px);
+}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -34,16 +34,7 @@
   border-radius: 4px;
 }
 
-/* Ensure the markdown editor toolbar stays visible below the sticky navbar */
-.editor-toolbar.fullscreen {
-  top: 4rem !important;
-  z-index: 60 !important;
-}
-.editor-toolbar.fullscreen::before,
-.editor-toolbar.fullscreen::after {
-  top: 4rem !important;
-  z-index: 60 !important;
-}
-.CodeMirror-fullscreen {
-  top: calc(4rem + 50px) !important;
+/* Hide the top navbar when a markdown editor is in fullscreen */
+body.hide-navbar .navbar {
+  display: none;
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -36,12 +36,14 @@
 
 /* Ensure the markdown editor toolbar stays visible below the sticky navbar */
 .editor-toolbar.fullscreen {
-  top: 4rem;
+  top: 4rem !important;
+  z-index: 60 !important;
 }
 .editor-toolbar.fullscreen::before,
 .editor-toolbar.fullscreen::after {
-  top: 4rem;
+  top: 4rem !important;
+  z-index: 60 !important;
 }
 .CodeMirror-fullscreen {
-  top: calc(4rem + 50px);
+  top: calc(4rem + 50px) !important;
 }

--- a/frontend/src/lib/MarkdownEditor.svelte
+++ b/frontend/src/lib/MarkdownEditor.svelte
@@ -55,6 +55,7 @@
       if (side || fs) {
         sidebarOpen.set(false);
       }
+      document.body.classList.toggle('hide-navbar', fs);
     };
 
     const handleSideBySide = () => {
@@ -101,6 +102,7 @@
     } finally {
       editor = null;
     }
+    document.body.classList.remove('hide-navbar');
   }
 
   onDestroy(() => {


### PR DESCRIPTION
## Summary
- ensure the EasyMDE toolbar stays visible when toggling fullscreen

## Testing
- `npm run check` *(fails: svelte-check found 11 errors and 28 warnings)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687d2bab6c408321b9d22af90abdee15