### PR TITLE
Profile settings with avatar

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -1157,3 +1157,28 @@ func updateFileContent(c *gin.Context) {
 	}
 	c.Status(http.StatusNoContent)
 }
+
+func updateProfile(c *gin.Context) {
+	uid := c.GetInt("userID")
+	var req struct {
+		Name   *string `json:"name"`
+		Avatar *string `json:"avatar"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	user, err := GetUser(uid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+		return
+	}
+	if user.BkUID != nil {
+		req.Name = nil // Bakalari users cannot change name
+	}
+	if err := UpdateUserProfile(uid, req.Name, req.Avatar); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -63,11 +63,20 @@ func main() {
 		})
 		// who am I
 		api.GET("/me", func(c *gin.Context) {
+			u, err := GetUser(c.GetInt("userID"))
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+				return
+			}
 			c.JSON(http.StatusOK, gin.H{
-				"id":   c.GetInt("userID"),
-				"role": c.GetString("role"),
+				"id":     u.ID,
+				"role":   u.Role,
+				"name":   u.Name,
+				"avatar": u.Avatar,
+				"bk_uid": u.BkUID,
 			})
 		})
+		api.PUT("/me", updateProfile)
 
 		// Assignments
 		api.GET("/assignments", RoleGuard("student", "teacher", "admin"), listAssignments)

--- a/backend/models.go
+++ b/backend/models.go
@@ -15,6 +15,7 @@ type User struct {
 	Email        string    `db:"email"`
 	PasswordHash string    `db:"password_hash"`
 	Name         *string   `db:"name"`
+	Avatar       *string   `db:"avatar"`
 	Role         string    `db:"role"`
 	BkClass      *string   `db:"bk_class"`
 	BkUID        *string   `db:"bk_uid"`
@@ -98,6 +99,21 @@ func UpdateUserRole(id int, role string) error {
 		return fmt.Errorf("invalid role")
 	}
 	_, err := DB.Exec(`UPDATE users SET role=$1 WHERE id=$2`, role, id)
+	return err
+}
+
+func GetUser(id int) (*User, error) {
+	var u User
+	err := DB.Get(&u, `SELECT id, email, password_hash, name, avatar, role, bk_class, bk_uid, created_at
+                FROM users WHERE id=$1`, id)
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func UpdateUserProfile(id int, name, avatar *string) error {
+	_, err := DB.Exec(`UPDATE users SET name=COALESCE($1,name), avatar=COALESCE($2,avatar) WHERE id=$3`, name, avatar, id)
 	return err
 }
 

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS users (
   email TEXT NOT NULL UNIQUE,
   password_hash TEXT NOT NULL,
   name TEXT,
+  avatar TEXT,
   role TEXT NOT NULL DEFAULT 'student' CHECK (role IN ('student','teacher','admin')),
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -11,6 +12,7 @@ CREATE TABLE IF NOT EXISTS users (
 ALTER TABLE users ADD COLUMN IF NOT EXISTS name TEXT;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS bk_class TEXT;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS bk_uid TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar TEXT;
 
 
 CREATE TABLE IF NOT EXISTS classes (

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,23 +1,35 @@
-import { writable } from 'svelte/store';
-import { apiFetch } from '$lib/api';
-import { browser } from '$app/environment';
+import { writable } from "svelte/store";
+import { apiFetch } from "$lib/api";
+import { browser } from "$app/environment";
 
-export type User = { id: number; role: string } | null;
+export type User = {
+  id: number;
+  role: string;
+  name?: string | null;
+  avatar?: string | null;
+  bk_uid?: string | null;
+} | null;
 
 function createAuth() {
   // Always start with null on both server and client…
   const { subscribe, set } = writable<User>(null);
 
   /** Called from Login.svelte after successful auth */
-  function login(id: number, role: string) {
-    set({ id, role });
+  function login(
+    id: number,
+    role: string,
+    name?: string | null,
+    avatar?: string | null,
+    bk_uid?: string | null,
+  ) {
+    set({ id, role, name, avatar, bk_uid });
   }
 
   /** Log out everywhere */
   async function logout() {
     if (browser) {
       try {
-        await apiFetch('/api/logout', { method: 'POST' });
+        await apiFetch("/api/logout", { method: "POST" });
       } catch {
         // ignore errors
       }
@@ -29,10 +41,16 @@ function createAuth() {
   async function init() {
     if (!browser) return; // don’t do anything on server
 
-    const r = await apiFetch('/api/me');
+    const r = await apiFetch("/api/me");
     if (r.ok) {
       const me = await r.json();
-      login(me.id, me.role);
+      login(
+        me.id,
+        me.role,
+        me.name ?? null,
+        me.avatar ?? null,
+        me.bk_uid ?? null,
+      );
     } else {
       logout();
     }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -5,10 +5,46 @@
   import '../app.css';
   import Sidebar from '$lib/Sidebar.svelte';
   import { sidebarOpen, sidebarCollapsed } from '$lib/sidebar';
+  import { apiFetch } from '$lib/api';
+
+  let settingsDialog: HTMLDialogElement;
+  let name = '';
+  let avatarFile: string | null = null;
 
   function logout() {
     auth.logout();
     goto('/login');
+  }
+
+  function openSettings() {
+    if (user) {
+      name = user.name ?? '';
+    }
+    avatarFile = null;
+    settingsDialog.showModal();
+  }
+
+  function onAvatarChange(e: Event) {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if (!file) { avatarFile = null; return; }
+    const reader = new FileReader();
+    reader.onload = () => { avatarFile = reader.result as string; };
+    reader.readAsDataURL(file);
+  }
+
+  async function saveSettings() {
+    const body: any = {};
+    if (avatarFile !== null) body.avatar = avatarFile;
+    if (user && user.bk_uid == null) body.name = name;
+    const res = await apiFetch('/api/me', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    if (res.ok) {
+      const meRes = await apiFetch('/api/me');
+      if (meRes.ok) {
+        const me = await meRes.json();
+        auth.login(me.id, me.role, me.name ?? null, me.avatar ?? null, me.bk_uid ?? null);
+      }
+    }
+    settingsDialog.close();
   }
 
   $: user = $auth;
@@ -50,12 +86,40 @@
       </div>
       <div class="flex-none gap-2">
         {#if user}
-          <details class="dropdown dropdown-end">
-            <summary class="btn" role="button">{user.role}</summary>
-            <ul class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-32">
+          <div class="dropdown dropdown-end">
+            <label tabindex="0" class="btn btn-ghost btn-circle avatar">
+              {#if user.avatar}
+                <div class="w-10 rounded-full"><img src={user.avatar} /></div>
+              {:else}
+                <div class="w-10 rounded-full bg-neutral text-neutral-content flex items-center justify-center">
+                  {user.role.slice(0,1).toUpperCase()}
+                </div>
+              {/if}
+            </label>
+            <ul tabindex="0" class="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-36">
+              <li><button on:click={openSettings}>Settings</button></li>
               <li><button on:click={logout}>Logout</button></li>
             </ul>
-          </details>
+          </div>
+          <dialog bind:this={settingsDialog} class="modal">
+            <div class="modal-box space-y-4">
+              <h3 class="font-bold text-lg">Settings</h3>
+              {#if user.bk_uid == null}
+                <label class="form-control w-full space-y-1">
+                  <span class="label-text">Name</span>
+                  <input class="input input-bordered w-full" bind:value={name} />
+                </label>
+              {/if}
+              <label class="form-control w-full space-y-1">
+                <span class="label-text">Avatar</span>
+                <input type="file" accept="image/*" on:change={onAvatarChange} />
+              </label>
+              <div class="modal-action">
+                <button class="btn" on:click={saveSettings}>Save</button>
+              </div>
+            </div>
+            <form method="dialog" class="modal-backdrop"><button>close</button></form>
+          </dialog>
         {:else}
           <a href="/login" class="btn">Login</a>
           <a href="/register" class="btn btn-outline">Register</a>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -31,7 +31,7 @@
       const me = await meRes.json()
 
       // 3. Store & smart-redirect
-      auth.login(me.id, me.role)
+      auth.login(me.id, me.role, me.name ?? null, me.avatar ?? null, me.bk_uid ?? null)
       goto('/dashboard')
     }
     async function submitBk() {
@@ -51,7 +51,7 @@
         return
       }
       const me = await meRes.json()
-      auth.login(me.id, me.role)
+      auth.login(me.id, me.role, me.name ?? null, me.avatar ?? null, me.bk_uid ?? null)
       goto('/dashboard')
     }
   </script>


### PR DESCRIPTION
## Summary
- add `avatar` column to users
- expose name and avatar from `/api/me`
- allow updating profile via new API endpoint
- show avatar button with Settings dropdown
- add settings modal to update name and avatar
- extend auth store with user details

## Testing
- `go test ./...`
- `npm run check` *(fails: svelte-check found errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687d3ead26188321aff2437a6a45a5dc