### PR TITLE
Link to class overview from dashboard

### DIFF
--- a/frontend/src/lib/Sidebar.svelte
+++ b/frontend/src/lib/Sidebar.svelte
@@ -40,12 +40,13 @@
             {c.name}
           </summary>
           <ul>
+            {#if $auth?.role === 'student'}
+              <li><a class={$page.url.pathname===`/classes/${c.id}/overview` ? 'active' : ''} href={`/classes/${c.id}/overview`} on:click={() => sidebarOpen.set(false)}>Overview</a></li>
+            {/if}
             <li><a class={$page.url.pathname===`/classes/${c.id}` ? 'active' : ''} href={`/classes/${c.id}`} on:click={() => sidebarOpen.set(false)}>Assignments</a></li>
             <li><a class={$page.url.pathname===`/classes/${c.id}/files` ? 'active' : ''} href={`/classes/${c.id}/files`} on:click={() => sidebarOpen.set(false)}>Files</a></li>
             <li><a class={$page.url.pathname===`/classes/${c.id}/notes` ? 'active' : ''} href={`/classes/${c.id}/notes`} on:click={() => sidebarOpen.set(false)}>Notes</a></li>
-            {#if $auth?.role === 'student'}
-              <li><a class={$page.url.pathname===`/classes/${c.id}/overview` ? 'active' : ''} href={`/classes/${c.id}/overview`} on:click={() => sidebarOpen.set(false)}>Overview</a></li>
-            {:else}
+            {#if $auth?.role !== 'student'}
               <li><a class={$page.url.pathname===`/classes/${c.id}/progress` ? 'active' : ''} href={`/classes/${c.id}/progress`} on:click={() => sidebarOpen.set(false)}>Progress</a></li>
             {/if}
           </ul>

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -100,7 +100,7 @@
   {#if role === 'student'}
     <div class="grid gap-6 md:grid-cols-2">
       {#each classes as c}
-        <a href={`/classes/${c.id}`} class="card bg-base-100 shadow hover:shadow-lg block">
+        <a href={`/classes/${c.id}/overview`} class="card bg-base-100 shadow hover:shadow-lg block">
           <div class="card-body">
             <h2 class="card-title">{c.name}</h2>
             <div class="stats stats-vertical lg:stats-horizontal mt-3">


### PR DESCRIPTION
## Summary
- open class overview when selecting a class from the dashboard
- show Overview first in the sidebar for students

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687d3fdb003083219da813e6a4e4ae38