### PR TITLE
Adjust new class creation UX

### DIFF
--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
-  import { slide } from 'svelte/transition';
   import { apiJSON, apiFetch } from '$lib/api';
   import AdminPanel from '$lib/AdminPanel.svelte';
 
@@ -179,12 +178,12 @@
       {/each}
     </div>
     {#if showNewClassInput}
-      <form class="mt-6 flex gap-2 max-w-sm" on:submit|preventDefault={createClass} in:slide={{axis:'x'}} out:slide={{axis:'x'}}>
+      <form class="mt-6 flex gap-2 max-w-sm" on:submit|preventDefault={createClass}>
         <input class="input input-bordered flex-1" placeholder="New class" bind:value={newClassName} bind:this={newClassInput} required />
         <button class="btn">Create</button>
       </form>
     {:else}
-      <button class="btn mt-6" on:click={showInput} in:slide={{axis:'x'}} out:slide={{axis:'x'}}>Create New Class</button>
+      <button class="btn mt-6" on:click={showInput}>Create New Class</button>
     {/if}
   {:else if role === 'admin'}
     <AdminPanel />

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -179,12 +179,12 @@
       {/each}
     </div>
     {#if showNewClassInput}
-      <form class="mt-6 flex gap-2 max-w-sm" on:submit|preventDefault={createClass} in:slide>
+      <form class="mt-6 flex gap-2 max-w-sm" on:submit|preventDefault={createClass} in:slide={{axis:'x'}} out:slide={{axis:'x'}}>
         <input class="input input-bordered flex-1" placeholder="New class" bind:value={newClassName} bind:this={newClassInput} required />
         <button class="btn">Create</button>
       </form>
     {:else}
-      <button class="btn mt-6" on:click={showInput}>Create New Class</button>
+      <button class="btn mt-6" on:click={showInput} in:slide={{axis:'x'}} out:slide={{axis:'x'}}>Create New Class</button>
     {/if}
   {:else if role === 'admin'}
     <AdminPanel />

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
+  import { slide } from 'svelte/transition';
   import { apiJSON, apiFetch } from '$lib/api';
   import AdminPanel from '$lib/AdminPanel.svelte';
 
@@ -10,6 +11,8 @@
   let loading = true;
   let err = '';
   let newClassName = '';
+  let showNewClassInput = false;
+  let newClassInput: HTMLInputElement | null = null;
 
   function percent(done:number,total:number){
     return total ? Math.round((done/total)*100) : 0;
@@ -89,7 +92,14 @@
       });
       classes = [...classes, { ...cl, assignments: [], students: [] }];
       newClassName='';
+      showNewClassInput = false;
     }catch(e:any){ err = e.message; }
+  }
+
+  async function showInput() {
+    showNewClassInput = true;
+    await tick();
+    newClassInput?.focus();
   }
 </script>
 
@@ -168,10 +178,14 @@
         </a>
       {/each}
     </div>
-    <form class="mt-6 flex gap-2 max-w-sm" on:submit|preventDefault={createClass}>
-      <input class="input input-bordered flex-1" placeholder="New class" bind:value={newClassName} required />
-      <button class="btn">Create</button>
-    </form>
+    {#if showNewClassInput}
+      <form class="mt-6 flex gap-2 max-w-sm" on:submit|preventDefault={createClass} in:slide>
+        <input class="input input-bordered flex-1" placeholder="New class" bind:value={newClassName} bind:this={newClassInput} required />
+        <button class="btn">Create</button>
+      </form>
+    {:else}
+      <button class="btn mt-6" on:click={showInput}>Create New Class</button>
+    {/if}
   {:else if role === 'admin'}
     <AdminPanel />
   {/if}


### PR DESCRIPTION
## Summary
- streamline new class creation on dashboard
- hide new class input until teacher clicks `Create New Class`

## Testing
- `npm run check` *(fails: svelte-check found 11 errors and 28 warnings)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687d480ce82c8321bb681f680f53d084