### PR TITLE
Add message pagination

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -1294,15 +1294,27 @@ func createMessage(c *gin.Context) {
 }
 
 func listMessages(c *gin.Context) {
-	otherID, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
-		return
-	}
-	msgs, err := ListMessages(c.GetInt("userID"), otherID)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
-		return
-	}
-	c.JSON(http.StatusOK, msgs)
+        otherID, err := strconv.Atoi(c.Param("id"))
+        if err != nil {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+                return
+        }
+        limit := 50
+        if l := c.Query("limit"); l != "" {
+                if v, err := strconv.Atoi(l); err == nil {
+                        limit = v
+                }
+        }
+        offset := 0
+        if o := c.Query("offset"); o != "" {
+                if v, err := strconv.Atoi(o); err == nil {
+                        offset = v
+                }
+        }
+        msgs, err := ListMessages(c.GetInt("userID"), otherID, limit, offset)
+        if err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+                return
+        }
+        c.JSON(http.StatusOK, msgs)
 }

--- a/backend/models.go
+++ b/backend/models.go
@@ -908,15 +908,16 @@ func CreateMessage(m *Message) error {
 		Scan(&m.ID, &m.CreatedAt)
 }
 
-func ListMessages(userID, otherID int) ([]Message, error) {
-	msgs := []Message{}
-	err := DB.Select(&msgs, `SELECT id,sender_id,recipient_id,content,created_at
+func ListMessages(userID, otherID, limit, offset int) ([]Message, error) {
+        msgs := []Message{}
+        err := DB.Select(&msgs, `SELECT id,sender_id,recipient_id,content,created_at
                                   FROM messages
                                  WHERE (sender_id=$1 AND recipient_id=$2)
                                     OR (sender_id=$2 AND recipient_id=$1)
-                                 ORDER BY created_at`,
-		userID, otherID)
-	return msgs, err
+                                 ORDER BY created_at
+                                 LIMIT $3 OFFSET $4`,
+                userID, otherID, limit, offset)
+        return msgs, err
 }
 
 type UserSearch struct {

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -123,4 +123,6 @@ CREATE TABLE IF NOT EXISTS messages (
   content TEXT NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+CREATE INDEX IF NOT EXISTS idx_messages_sender_recipient_created
+  ON messages(sender_id, recipient_id, created_at);
 

--- a/frontend/src/routes/messages/+page.svelte
+++ b/frontend/src/routes/messages/+page.svelte
@@ -11,6 +11,9 @@
   let target: User | null = null;
   let msg = '';
   let err = '';
+  const pageSize = 20;
+  let offset = 0;
+  let hasMore = true;
 
   async function search() {
     const r = await apiJSON(`/api/user-search?q=${encodeURIComponent(searchTerm)}`);
@@ -19,12 +22,15 @@
 
   async function openChat(u: any) {
     target = u;
+    convo = [];
+    offset = 0;
+    hasMore = true;
     await load();
   }
 
-  async function load() {
+  async function load(more = false) {
     if (!target) return;
-    const list = await apiJSON(`/api/messages/${target.id}`);
+    const list = await apiJSON(`/api/messages/${target.id}?limit=${pageSize}&offset=${offset}`);
     const k = getKey();
     for (const m of list) {
       if (k) {
@@ -34,7 +40,10 @@
         m.text = '[locked]';
       }
     }
-    convo = list;
+    if (more) convo = [...convo, ...list];
+    else convo = list;
+    offset += list.length;
+    if (list.length < pageSize) hasMore = false;
   }
 
   async function send() {
@@ -47,7 +56,7 @@
       method:'POST', headers:{'Content-Type':'application/json'},
       body: JSON.stringify({ to: target.id, content: ct })
     });
-    if (res.ok) { msg=''; await load(); }
+    if (res.ok) { msg=''; offset=0; await load(); }
     else { err = (await res.json()).error; }
   }
 </script>
@@ -63,6 +72,9 @@
 
 {#if target}
   <h2 class="font-bold mb-2">Chat with {target.name ?? target.email}</h2>
+  {#if hasMore}
+    <button class="btn btn-sm mb-2" on:click={() => load(true)}>Load more</button>
+  {/if}
   <div class="space-y-2 max-h-60 overflow-y-auto mb-2 border p-2">
     {#each convo as m}
       <div class={m.sender_id === $auth?.id ? 'text-right' : 'text-left'}>


### PR DESCRIPTION
## Summary
- index messages by sender, recipient, and time
- support limit/offset arguments when listing messages
- parse pagination query params in the message handler
- load messages incrementally in the frontend

## Testing
- `cd backend && go test ./... && cd ..`

------
https://chatgpt.com/codex/tasks/task_e_687f75d7537083219ae414dde54c4e2f