### PR TITLE
Implement conversation list

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -1294,27 +1294,48 @@ func createMessage(c *gin.Context) {
 }
 
 func listMessages(c *gin.Context) {
-        otherID, err := strconv.Atoi(c.Param("id"))
-        if err != nil {
-                c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
-                return
-        }
-        limit := 50
-        if l := c.Query("limit"); l != "" {
-                if v, err := strconv.Atoi(l); err == nil {
-                        limit = v
-                }
-        }
-        offset := 0
-        if o := c.Query("offset"); o != "" {
-                if v, err := strconv.Atoi(o); err == nil {
-                        offset = v
-                }
-        }
-        msgs, err := ListMessages(c.GetInt("userID"), otherID, limit, offset)
-        if err != nil {
-                c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
-                return
-        }
-        c.JSON(http.StatusOK, msgs)
+	otherID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	limit := 50
+	if l := c.Query("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil {
+			limit = v
+		}
+	}
+	offset := 0
+	if o := c.Query("offset"); o != "" {
+		if v, err := strconv.Atoi(o); err == nil {
+			offset = v
+		}
+	}
+	msgs, err := ListMessages(c.GetInt("userID"), otherID, limit, offset)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+		return
+	}
+	c.JSON(http.StatusOK, msgs)
+}
+
+func listConversations(c *gin.Context) {
+	limit := 20
+	if l := c.Query("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil {
+			limit = v
+		}
+	}
+	offset := 0
+	if o := c.Query("offset"); o != "" {
+		if v, err := strconv.Atoi(o); err == nil {
+			offset = v
+		}
+	}
+	list, err := ListConversations(c.GetInt("userID"), limit, offset)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+		return
+	}
+	c.JSON(http.StatusOK, list)
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -131,6 +131,7 @@ func main() {
 
 		// Messaging
 		api.GET("/user-search", RoleGuard("student", "teacher", "admin"), searchUsers)
+		api.GET("/conversations", RoleGuard("student", "teacher", "admin"), listConversations)
 		api.POST("/messages", RoleGuard("student", "teacher", "admin"), createMessage)
 		api.GET("/messages/:id", RoleGuard("student", "teacher", "admin"), listMessages)
 		api.GET("/messages/events", RoleGuard("student", "teacher", "admin"), messageEventsHandler)


### PR DESCRIPTION
## Summary
- add a `ListConversations` model with DB query for recent chats
- expose `/api/conversations` endpoint in backend
- update messaging frontend to show recent conversations

## Testing
- `go test ./...`
- `npm --prefix frontend run build` *(fails: worker.format issue)*

------
https://chatgpt.com/codex/tasks/task_e_687f9a263bec8321b445f57439ead414