### PR TITLE
Fix SSE disconnections

### DIFF
--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -3,3 +3,4 @@ export { default as MarkdownEditor } from './MarkdownEditor.svelte';
 export { default as FileTree } from './FileTree.svelte';
 export { default as AdminPanel } from './AdminPanel.svelte';
 export { default as NotebookEditor } from './components/NotebookEditor.svelte';
+export * from './sse';

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -1,0 +1,41 @@
+export interface SSEOptions {
+  /** milliseconds before attempting to reconnect */
+  retry?: number;
+  /** called with a message when the connection is lost */
+  onError?: (msg: string) => void;
+  /** called when a new connection opens */
+  onOpen?: () => void;
+}
+
+export function createEventSource(
+  url: string,
+  setup: (es: EventSource) => void,
+  opts: SSEOptions = {}
+) {
+  let es: EventSource | null = null;
+  let closed = false;
+  const retry = opts.retry ?? 5000;
+
+  function connect() {
+    es = new EventSource(url);
+    setup(es!);
+    es.onopen = () => {
+      opts.onOpen?.();
+    };
+    es.onerror = () => {
+      if (closed) return;
+      opts.onError?.("Lost connection, retrying…");
+      es?.close();
+      setTimeout(connect, retry);
+    };
+  }
+
+  connect();
+
+  return {
+    close() {
+      closed = true;
+      es?.close();
+    }
+  };
+}

--- a/frontend/src/routes/submissions/+page.svelte
+++ b/frontend/src/routes/submissions/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { apiJSON } from '$lib/api';
+  import { createEventSource } from '$lib/sse';
 
   interface Submission {
     id: number;
@@ -14,7 +15,7 @@
   let titles: Record<number,string> = {};
   let loading = true;
   let err = '';
-  let es: EventSource | null = null;
+  let esCtrl: { close: () => void } | null = null;
 
   function resultColor(s: string){
     if(s === 'passed') return 'badge-success';
@@ -50,8 +51,10 @@
 
   onMount(() => {
     load();
-    es = new EventSource('/api/events');
-    es.addEventListener('status', (ev) => {
+    esCtrl = createEventSource(
+      '/api/events',
+      (src) => {
+    src.addEventListener('status', (ev) => {
       const d = JSON.parse((ev as MessageEvent).data);
       const s = subs.find((x) => x.id === d.submission_id);
       if (s) {
@@ -59,15 +62,21 @@
         if (d.status !== 'running') load();
       }
     });
-    es.addEventListener('result', (ev) => {
+    src.addEventListener('result', (ev) => {
       const d = JSON.parse((ev as MessageEvent).data);
       const s = subs.find((x) => x.id === d.submission_id);
       if (s) {
         s.results = [...(s.results ?? []), d];
       }
     });
+      },
+      {
+        onError: (m) => { err = m; },
+        onOpen: () => { err = ''; }
+      }
+    );
   });
-  onDestroy(() => { es?.close(); });
+  onDestroy(() => { esCtrl?.close(); });
 </script>
 
 {#if loading}

--- a/frontend/src/routes/submissions/[id]/+page.svelte
+++ b/frontend/src/routes/submissions/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte'
   import { apiJSON } from '$lib/api'
+  import { createEventSource } from '$lib/sse'
   import { page } from '$app/stores'
   import JSZip from 'jszip'
   import { FileTree } from '$lib'
@@ -14,7 +15,7 @@ $: id = $page.params.id
   let tree: FileNode[] = []
   let selected: { name: string; content: string } | null = null
   let highlighted = ''
-  let es: EventSource | null = null
+  let esCtrl: { close: () => void } | null = null
 
   import hljs from 'highlight.js'
   import 'highlight.js/styles/github.css'
@@ -123,22 +124,30 @@ $: id = $page.params.id
 
   onMount(() => {
     load()
-    es = new EventSource('/api/events')
-    es.addEventListener('status', (ev) => {
+    esCtrl = createEventSource(
+      '/api/events',
+      (src) => {
+    src.addEventListener('status', (ev) => {
       const d = JSON.parse((ev as MessageEvent).data)
       if (submission && d.submission_id === submission.id) {
         submission.status = d.status
         if (d.status !== 'running') load()
       }
     })
-    es.addEventListener('result', (ev) => {
+    src.addEventListener('result', (ev) => {
       const d = JSON.parse((ev as MessageEvent).data)
       if (submission && d.submission_id === submission.id) {
         results = [...results, d]
       }
     })
+      },
+      {
+        onError: (m) => { err = m },
+        onOpen: () => { err = '' }
+      }
+    )
   })
-  onDestroy(() => { es?.close() })
+  onDestroy(() => { esCtrl?.close() })
 </script>
 
 {#if !submission}


### PR DESCRIPTION
## Summary
- add reconnectable EventSource helper
- use new helper on pages that consume SSE streams
- export helper from `$lib`

## Testing
- `npm --prefix frontend run build` *(fails: Invalid value "iife" for option "worker.format")*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687f9a7d06208321baa6458df3e41381