### PR TITLE
Fix message pagination

### DIFF
--- a/backend/models.go
+++ b/backend/models.go
@@ -913,15 +913,15 @@ func CreateMessage(m *Message) error {
 }
 
 func ListMessages(userID, otherID, limit, offset int) ([]Message, error) {
-        msgs := []Message{}
-        err := DB.Select(&msgs, `SELECT id,sender_id,recipient_id,content,created_at
-                                  FROM messages
-                                 WHERE (sender_id=$1 AND recipient_id=$2)
-                                    OR (sender_id=$2 AND recipient_id=$1)
-                                 ORDER BY created_at
-                                 LIMIT $3 OFFSET $4`,
-                userID, otherID, limit, offset)
-        return msgs, err
+	msgs := []Message{}
+	err := DB.Select(&msgs, `SELECT id,sender_id,recipient_id,content,created_at
+                                 FROM messages
+                                WHERE (sender_id=$1 AND recipient_id=$2)
+                                   OR (sender_id=$2 AND recipient_id=$1)
+                                ORDER BY created_at DESC
+                                LIMIT $3 OFFSET $4`,
+		userID, otherID, limit, offset)
+	return msgs, err
 }
 
 type UserSearch struct {

--- a/frontend/src/routes/messages/+page.svelte
+++ b/frontend/src/routes/messages/+page.svelte
@@ -41,6 +41,7 @@
   async function load(more = false) {
     if (!target) return;
     const list = await apiJSON(`/api/messages/${target.id}?limit=${pageSize}&offset=${offset}`);
+    list.reverse();
     const k = getKey();
     for (const m of list) {
       if (k) {
@@ -50,7 +51,7 @@
         m.text = '[locked]';
       }
     }
-    if (more) convo = [...convo, ...list];
+    if (more) convo = [...list, ...convo];
     else convo = list;
     offset += list.length;
     if (list.length < pageSize) hasMore = false;


### PR DESCRIPTION
## Summary
- fetch messages in descending order
- reverse result and prepend when loading older messages

## Testing
- `go test ./backend/...`
- `npm run check` *(fails: svelte-check found 15 errors and 35 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687fa3d749d08321975e315c20e57aed