### PR TITLE
Add progress bar for assignment points

### DIFF
--- a/frontend/src/routes/assignments/[id]/+page.svelte
+++ b/frontend/src/routes/assignments/[id]/+page.svelte
@@ -302,9 +302,12 @@ $: safeDesc = assignment ? DOMPurify.sanitize(marked.parse(assignment.descriptio
         <div class="flex justify-between items-start">
           <h1 class="card-title text-2xl">{assignment.title}</h1>
           {#if role==='student'}
-            <div class="flex items-center gap-2">
-              <div class="radial-progress text-primary" style="--value:{percent};" aria-valuenow={percent} role="progressbar">{percent}%</div>
-              <span class="font-semibold">{pointsEarned} / {assignment.max_points} pts</span>
+            <div class="flex flex-col items-end gap-1">
+              <div class="flex items-center gap-2">
+                <div class="radial-progress text-primary" style="--value:{percent};" aria-valuenow={percent} role="progressbar">{percent}%</div>
+                <span class="font-semibold">{pointsEarned} / {assignment.max_points} pts</span>
+              </div>
+              <progress class="progress progress-primary w-32" value={pointsEarned} max={assignment.max_points}></progress>
             </div>
           {/if}
         </div>


### PR DESCRIPTION
## Summary
- show radial and linear progress indicators for students on assignment page

## Testing
- `go test ./...`
- `npm run build` *(fails: Invalid value "iife" for option "worker.format")*

------
https://chatgpt.com/codex/tasks/task_e_687fad3bb14c83218d9b18664f8c2812