### PR TITLE
Use consistent 24‑hour date format

### DIFF
--- a/frontend/src/lib/AdminPanel.svelte
+++ b/frontend/src/lib/AdminPanel.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { apiFetch, apiJSON } from '$lib/api';
   import { sha256 } from '$lib/hash';
+  import { formatDate } from "$lib/date";
 
   // tabs state
   let tab: 'teachers' | 'users' | 'classes' = 'teachers';
@@ -87,7 +88,7 @@
                 {#each roles as r}<option>{r}</option>{/each}
               </select>
             </td>
-            <td>{new Date(u.created_at).toLocaleDateString()}</td>
+            <td>{formatDate(u.created_at)}</td>
           </tr>
         {/each}
         {#if !users.length}
@@ -110,7 +111,7 @@
             <td>{c.id}</td>
             <td><a href={`/classes/${c.id}`} class="link link-primary">{c.name}</a></td>
             <td>{c.teacher_id}</td>
-            <td>{new Date(c.created_at).toLocaleDateString()}</td>
+            <td>{formatDate(c.created_at)}</td>
           </tr>
         {/each}
         {#if !classes.length}

--- a/frontend/src/lib/date.ts
+++ b/frontend/src/lib/date.ts
@@ -1,0 +1,18 @@
+export function formatDateTime(value: string | number | Date): string {
+  return new Date(value).toLocaleString(undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23'
+  });
+}
+
+export function formatDate(value: string | number | Date): string {
+  return new Date(value).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+}

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -3,3 +3,4 @@ export { default as MarkdownEditor } from './MarkdownEditor.svelte';
 export { default as FileTree } from './FileTree.svelte';
 export { default as AdminPanel } from './AdminPanel.svelte';
 export { default as NotebookEditor } from './components/NotebookEditor.svelte';
+export * from './date';

--- a/frontend/src/routes/assignments/[id]/+page.svelte
+++ b/frontend/src/routes/assignments/[id]/+page.svelte
@@ -5,6 +5,7 @@ import { onMount, onDestroy, tick } from 'svelte'
 import { apiFetch, apiJSON } from '$lib/api'
 import { MarkdownEditor } from '$lib'
 import { marked } from 'marked'
+import { formatDateTime } from "$lib/date";
 import DOMPurify from 'dompurify'
 import { goto } from '$app/navigation'
 import { page } from '$app/stores'
@@ -309,7 +310,7 @@ $: safeDesc = assignment ? DOMPurify.sanitize(marked.parse(assignment.descriptio
           {/if}
         </div>
         <div class="markdown">{@html safeDesc}</div>
-        <p><strong>Deadline:</strong> {new Date(assignment.deadline).toLocaleString()}</p>
+        <p><strong>Deadline:</strong> {formatDateTime(assignment.deadline)}</p>
         <p><strong>Max points:</strong> {assignment.max_points}</p>
         <p><strong>Policy:</strong> {assignment.grading_policy}</p>
         {#if assignment.template_path}
@@ -350,7 +351,7 @@ $: safeDesc = assignment ? DOMPurify.sanitize(marked.parse(assignment.descriptio
             <tr class="cursor-pointer" on:click={() => toggleStudent(p.student.id)}>
               <td>{p.student.name ?? p.student.email}</td>
               <td><span class={`badge ${statusColor(p.latest ? p.latest.status : 'none')}`}>{p.latest ? p.latest.status : 'none'}</span></td>
-              <td>{p.latest ? new Date(p.latest.created_at).toLocaleString() : '-'}</td>
+              <td>{p.latest ? formatDateTime(p.latest.created_at) : '-'}</td>
             </tr>
             {#if expanded === p.student.id}
               <tr>
@@ -372,7 +373,7 @@ $: safeDesc = assignment ? DOMPurify.sanitize(marked.parse(assignment.descriptio
                             {/if}
                           </div>
                           <div class="timeline-end timeline-box flex items-center m-0">
-                            <a class="link" href={`/submissions/${s.id}`} on:click={saveState}>{new Date(s.created_at).toLocaleString()}</a>
+                            <a class="link" href={`/submissions/${s.id}`} on:click={saveState}>{formatDateTime(s.created_at)}</a>
                           </div>
                           {#if i !== p.all.length - 1}<hr />{/if}
                         </li>
@@ -408,7 +409,7 @@ $: safeDesc = assignment ? DOMPurify.sanitize(marked.parse(assignment.descriptio
             <tbody>
               {#each submissions as s}
                 <tr>
-                  <td>{new Date(s.created_at).toLocaleString()}</td>
+                  <td>{formatDateTime(s.created_at)}</td>
                   <td><span class={`badge ${statusColor(s.status)}`}>{s.status}</span></td>
                   <td><a href={`/submissions/${s.id}`} class="btn btn-sm btn-outline">view</a></td>
                 </tr>

--- a/frontend/src/routes/classes/[id]/+page.svelte
+++ b/frontend/src/routes/classes/[id]/+page.svelte
@@ -3,6 +3,7 @@
   import { get } from 'svelte/store';
   import { auth } from '$lib/auth';
 import { apiFetch, apiJSON } from '$lib/api';
+import { formatDateTime } from "$lib/date";
 import { page } from '$app/stores';
 import { goto } from '$app/navigation';
 import { marked } from 'marked';
@@ -175,7 +176,7 @@ import { marked } from 'marked';
                 <div class="card-body flex-col sm:flex-row justify-between items-start sm:items-center gap-2 py-3">
                   <span class="text-lg font-semibold text-primary">{a.title}</span>
                   <div class="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:justify-end w-full sm:w-auto">
-                    <span class={`badge ${new Date(a.deadline)<new Date() && !a.completed ? 'badge-error' : 'badge-info'}`}>{new Date(a.deadline).toLocaleString()}</span>
+                    <span class={`badge ${new Date(a.deadline)<new Date() && !a.completed ? 'badge-error' : 'badge-info'}`}>{formatDateTime(a.deadline)}</span>
                     <span class="text-sm">{countdown(a.deadline)}</span>
                     {#if role==='teacher' || role==='admin'}
                       {#if a.published}

--- a/frontend/src/routes/classes/[id]/files/+page.svelte
+++ b/frontend/src/routes/classes/[id]/files/+page.svelte
@@ -7,6 +7,7 @@ import { auth } from '$lib/auth';
 import { apiJSON, apiFetch } from '$lib/api';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
+import { formatDateTime } from "$lib/date";
 let id = $page.params.id;
 $: if ($page.params.id !== id) { id = $page.params.id; load(currentParent); }
 const role: string = get(auth)?.role ?? '';
@@ -364,7 +365,7 @@ onMount(()=>load(null));
               {/if}
             </td>
             <td class="text-right">{it.is_dir ? '' : fmtSize(it.size)}</td>
-            <td class="text-right">{new Date(it.updated_at).toLocaleString()}</td>
+            <td class="text-right">{formatDateTime(it.updated_at)}</td>
 
             {#if role === 'teacher' || role === 'admin'}
               <td class="text-right whitespace-nowrap w-16">

--- a/frontend/src/routes/classes/[id]/notes/+page.svelte
+++ b/frontend/src/routes/classes/[id]/notes/+page.svelte
@@ -2,6 +2,7 @@
 import { onMount } from 'svelte';
 import { apiJSON } from '$lib/api';
 import { page } from '$app/stores';
+import { formatDateTime } from "$lib/date";
 import { goto } from '$app/navigation';
 
 let id = $page.params.id;
@@ -62,7 +63,7 @@ onMount(load);
               <i class="fa-solid fa-book text-secondary mr-2"></i>{n.name}
             </td>
             <td class="text-right">{fmtSize(n.size)}</td>
-            <td class="text-right">{new Date(n.updated_at).toLocaleString()}</td>
+            <td class="text-right">{formatDateTime(n.updated_at)}</td>
           </tr>
         {/each}
         {#if !notes.length}

--- a/frontend/src/routes/classes/[id]/overview/+page.svelte
+++ b/frontend/src/routes/classes/[id]/overview/+page.svelte
@@ -2,6 +2,7 @@
 import { onMount } from 'svelte';
 import { apiJSON } from '$lib/api';
 import { page } from '$app/stores';
+import { formatDateTime } from "$lib/date";
 
 let id = $page.params.id;
 $: if ($page.params.id !== id) { id = $page.params.id; load(); }
@@ -78,7 +79,7 @@ onMount(load);
     {#each cls.upcoming as a}
       <li class="flex justify-between items-center">
         <a href={`/assignments/${a.id}`} class="link">{a.title}</a>
-        <span class="badge badge-info">{new Date(a.deadline).toLocaleString()}</span>
+        <span class="badge badge-info">{formatDateTime(a.deadline)}</span>
       </li>
     {/each}
     {#if !cls.upcoming.length}

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount, tick } from 'svelte';
   import { apiJSON, apiFetch } from '$lib/api';
   import AdminPanel from '$lib/AdminPanel.svelte';
+  import { formatDateTime } from "$lib/date";
 
   let role = '';
   let classes:any[] = [];
@@ -153,7 +154,7 @@
             class="flex justify-between items-center p-3 bg-base-100 rounded shadow hover:bg-base-200"
           >
             <span>{a.title} <span class="text-sm text-base-content/60">({a.class})</span></span>
-            <span class="badge badge-info">{new Date(a.deadline).toLocaleString()}</span>
+            <span class="badge badge-info">{formatDateTime(a.deadline)}</span>
           </a>
         </li>
       {/each}

--- a/frontend/src/routes/submissions/+page.svelte
+++ b/frontend/src/routes/submissions/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { apiJSON } from '$lib/api';
 
+  import { formatDateTime } from "$lib/date";
   interface Submission {
     id: number;
     assignment_id: number;
@@ -82,7 +83,7 @@
       <tbody>
         {#each subs as s}
           <tr>
-            <td>{new Date(s.created_at).toLocaleString()}</td>
+            <td>{formatDateTime(s.created_at)}</td>
             <td>{titles[s.assignment_id] ?? s.assignment_id}</td>
             <td><span class={`badge ${statusColor(s.status)}`}>{s.status}</span></td>
             <td>


### PR DESCRIPTION
## Summary
- refine `formatDateTime` helper and include date options
- export date helpers via `$lib`
- apply `formatDateTime` across pages so timestamps use 24‑hour clock

## Testing
- `go test ./...`
- `npm run check` *(fails: svelte-check found 13 errors and 35 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687faca603648321b2e1c37fe8b529c6