### PR TITLE
Implement chat UI styling

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -38,3 +38,19 @@
 body.hide-navbar .navbar {
   display: none;
 }
+
+.chat-area {
+  @apply bg-gradient-to-b from-base-100 to-base-200;
+}
+
+.self-bubble {
+  @apply rounded-lg rounded-tl-none shadow;
+}
+
+.other-bubble {
+  @apply rounded-lg rounded-tr-none shadow;
+}
+
+.chat-timestamp {
+  @apply text-xs text-base-content/60;
+}

--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -16,12 +16,23 @@
     load();
   }
   const name = $page.url.searchParams.get('name') ?? $page.url.searchParams.get('email') ?? id;
+  const initial = (name ?? '').charAt(0).toUpperCase();
 
   let convo: any[] = [];
   let msg = '';
   let err = '';
   let esCtrl: { close: () => void } | null = null;
   let chatBox: HTMLDivElement | null = null;
+  const gapMs = 5 * 60 * 1000;
+
+  function showAvatar(idx: number, m: any) {
+    if (m.sender_id === $auth?.id) return false;
+    if (idx === 0) return true;
+    const prev = convo[idx - 1];
+    const t1 = new Date(prev.created_at).getTime();
+    const t2 = new Date(m.created_at).getTime();
+    return prev.sender_id !== m.sender_id || t2 - t1 > gapMs;
+  }
 
   afterUpdate(() => { if (chatBox) chatBox.scrollTop = chatBox.scrollHeight; });
 
@@ -95,11 +106,16 @@
 {#if hasMore}
   <button class="btn btn-sm mb-2" on:click={() => load(true)}>Load more</button>
 {/if}
-<div class="space-y-2 max-h-60 overflow-y-auto mb-2 border p-2" bind:this={chatBox}>
-  {#each convo as m}
+<div class="chat-area space-y-2 max-h-60 overflow-y-auto mb-2 border p-2" bind:this={chatBox}>
+  {#each convo as m, i}
     <div class={`chat ${m.sender_id === $auth?.id ? 'chat-end' : 'chat-start'}`}>
-      <div class={`chat-bubble ${m.sender_id === $auth?.id ? 'chat-bubble-primary' : 'chat-bubble-secondary'}`}>{m.text}</div>
-      <div class="chat-footer opacity-50 text-xs">{new Date(m.created_at).toLocaleString()}</div>
+      {#if showAvatar(i, m)}
+        <div class="chat-image avatar">
+          <div class="w-8 rounded-full bg-neutral text-neutral-content flex items-center justify-center">{initial}</div>
+        </div>
+      {/if}
+      <div class={`chat-bubble ${m.sender_id === $auth?.id ? 'chat-bubble-primary self-bubble' : 'chat-bubble-secondary other-bubble'}`}>{m.text}</div>
+      <div class="chat-footer chat-timestamp">{new Date(m.created_at).toLocaleString()}</div>
     </div>
   {/each}
 </div>


### PR DESCRIPTION
## Summary
- style message bubbles with softer corners and drop shadows
- show avatar initial for chat partner when time gap occurs
- add subtle gradient background and muted timestamp styling

## Testing
- `npm run build` *(fails: worker format not supported)*

------
https://chatgpt.com/codex/tasks/task_e_687fb9b398288321959181e43215aa2a