### PR TITLE
Adjust chat layout

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -215,7 +215,7 @@
       </div>
     </div>
 
-    <main class="w-full flex-1 p-4 flex flex-col overflow-hidden">
+    <main class="w-full flex-1 p-4 pb-0 flex flex-col overflow-hidden">
       <slot />
     </main>
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -215,7 +215,7 @@
       </div>
     </div>
 
-    <main class="container mx-auto flex-1 p-4">
+    <main class="container mx-auto flex-1 p-4 flex flex-col">
       <slot />
     </main>
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -215,7 +215,7 @@
       </div>
     </div>
 
-    <main class="container mx-auto flex-1 p-4 flex flex-col">
+    <main class="w-full flex-1 p-4 flex flex-col overflow-hidden">
       <slot />
     </main>
 

--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -123,7 +123,7 @@
     </div>
   </div>
   <div class="flex-1 overflow-hidden">
-    <div class="h-full overflow-y-auto p-4 space-y-4" bind:this={chatBox}>
+    <div class="h-full overflow-y-auto p-4 pb-24 space-y-4" bind:this={chatBox}>
       {#if hasMore}
         <div class="text-center">
           <button class="btn btn-sm" on:click={() => load(true)}>Load more</button>
@@ -153,7 +153,7 @@
       {/each}
     </div>
   </div>
-  <div class="p-3 border-t">
+  <div class="p-3 border-t bg-base-100 sticky bottom-0">
     <div class="flex items-center gap-2">
       <input class="input input-bordered flex-1" placeholder="Type a message..." bind:value={msg} />
       <button class="btn btn-primary" on:click={send} disabled={!msg.trim()}>Send</button>

--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -110,8 +110,8 @@
 
 <button class="btn btn-sm mb-4" on:click={back}>Back</button>
 
-<div class="card bg-base-100 shadow w-full h-full flex flex-col">
-  <div class="p-4 border-b flex items-center gap-3">
+<div class="card bg-base-100 shadow w-full flex-1 flex flex-col">
+  <div class="p-4 border-b flex items-center gap-3 sticky top-0 bg-base-100 z-10">
     <div class="avatar">
       <div class="w-10 rounded-full">
         <img src="/placeholder.svg?height=40&width=40" alt="Contact" />
@@ -123,7 +123,7 @@
     </div>
   </div>
   <div class="flex-1 overflow-hidden">
-    <div class="h-full overflow-y-auto p-4 pb-24 space-y-4" bind:this={chatBox}>
+    <div class="h-full overflow-y-auto p-4 space-y-4" bind:this={chatBox}>
       {#if hasMore}
         <div class="text-center">
           <button class="btn btn-sm" on:click={() => load(true)}>Load more</button>
@@ -153,7 +153,7 @@
       {/each}
     </div>
   </div>
-  <div class="p-3 border-t bg-base-100 sticky bottom-0">
+  <div class="p-3 border-t bg-base-100 sticky bottom-0 z-10">
     <div class="flex items-center gap-2">
       <input class="input input-bordered flex-1" placeholder="Type a message..." bind:value={msg} />
       <button class="btn btn-primary" on:click={send} disabled={!msg.trim()}>Send</button>

--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -110,7 +110,7 @@
 
 <button class="btn btn-sm mb-4" on:click={back}>Back</button>
 
-<div class="card bg-base-100 shadow w-full max-w-md mx-auto h-[600px] flex flex-col">
+<div class="card bg-base-100 shadow w-full h-full flex flex-col">
   <div class="p-4 border-b flex items-center gap-3">
     <div class="avatar">
       <div class="w-10 rounded-full">


### PR DESCRIPTION
## Summary
- expand chat card to full width
- make main page flex column so chat height fills container

## Testing
- `go test ./...`
- `npm run check` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_688113099c3c8321b24ee744274252d2