### PR TITLE
Improve chat message input

### DIFF
--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -159,7 +159,7 @@
               </div>
             {/if}
             <div>
-              <div class={`rounded-lg p-3 ${m.sender_id === $auth?.id ? 'bg-primary text-primary-content' : 'bg-base-200'}`}>{m.text}</div>
+              <div class={`rounded-lg p-3 whitespace-pre-wrap break-words ${m.sender_id === $auth?.id ? 'bg-primary text-primary-content' : 'bg-base-200'}`}>{m.text}</div>
               <div class={`flex items-center mt-1 text-xs opacity-60 ${m.sender_id === $auth?.id ? 'justify-end' : 'justify-start'}`}>{formatTime(m.created_at)}</div>
             </div>
           </div>
@@ -169,7 +169,7 @@
   </div>
   <div class="p-3 border-t">
     <div class="flex items-center gap-2">
-      <input class="input input-bordered flex-1" placeholder="Type a message..." bind:value={msg} />
+      <textarea class="textarea textarea-bordered flex-1 resize-y" rows="2" placeholder="Type a message..." bind:value={msg}></textarea>
       <button class="btn btn-primary" on:click={send} disabled={!msg.trim()}>Send</button>
     </div>
     {#if err}<p class="text-error mt-2">{err}</p>{/if}

--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -38,6 +38,14 @@
     return date.toLocaleDateString()
   }
 
+  function hyphenateLongWords(text: string, max = 20) {
+    return text.replace(new RegExp(`\\S{${max},}`, 'g'), (word) => {
+      const parts = []
+      for (let i = 0; i < word.length; i += max) parts.push(word.slice(i, i + max))
+      return parts.join('\u00AD')
+    })
+  }
+
   function sameDate(a: string | number | Date, b: string | number | Date) {
     return new Date(a).toDateString() === new Date(b).toDateString()
   }
@@ -159,7 +167,7 @@
               </div>
             {/if}
             <div>
-              <div class={`rounded-lg p-3 whitespace-pre-wrap break-words ${m.sender_id === $auth?.id ? 'bg-primary text-primary-content' : 'bg-base-200'}`}>{m.text}</div>
+              <div class={`rounded-lg p-3 whitespace-pre-wrap break-words ${m.sender_id === $auth?.id ? 'bg-primary text-primary-content' : 'bg-base-200'}`}>{hyphenateLongWords(m.text)}</div>
               <div class={`flex items-center mt-1 text-xs opacity-60 ${m.sender_id === $auth?.id ? 'justify-end' : 'justify-start'}`}>{formatTime(m.created_at)}</div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- allow multiline message entry in chat using `<textarea>`
- keep long chat messages from overflowing by enabling wrapping and newline support

## Testing
- `go test ./...`
- `npm run build --prefix frontend` *(fails: worker.format IIFE not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68822336c7a48321ba35bd159faae580