### PR TITLE
Fix scroll reset on loading older chat messages

### DIFF
--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -50,13 +50,30 @@
     return new Date(a).toDateString() === new Date(b).toDateString()
   }
 
-  afterUpdate(() => { if (chatBox) chatBox.scrollTop = chatBox.scrollHeight; });
+  let preserveScroll = false;
+  let prevHeight = 0;
+  let prevTop = 0;
+
+  afterUpdate(() => {
+    if (!chatBox) return;
+    if (preserveScroll) {
+      chatBox.scrollTop = prevTop + (chatBox.scrollHeight - prevHeight);
+      preserveScroll = false;
+    } else {
+      chatBox.scrollTop = chatBox.scrollHeight;
+    }
+  });
 
   const pageSize = 20;
   let offset = 0;
   let hasMore = true;
 
   async function load(more = false) {
+    if (more && chatBox) {
+      preserveScroll = true;
+      prevHeight = chatBox.scrollHeight;
+      prevTop = chatBox.scrollTop;
+    }
     const list = await apiJSON(`/api/messages/${id}?limit=${pageSize}&offset=${offset}`);
     list.reverse();
     const k = getKey();


### PR DESCRIPTION
## Summary
- keep chat box scroll position when older messages are loaded

## Testing
- `go test ./...`
- `npm --prefix frontend run check` *(fails: svelte-check found 20 errors and 35 warnings in 12 files)*

------
https://chatgpt.com/codex/tasks/task_e_688228a576bc83219c3bf3cff3ef4f48