### PR TITLE
Enable E2EE for images

### DIFF
--- a/frontend/src/lib/e2ee.ts
+++ b/frontend/src/lib/e2ee.ts
@@ -44,13 +44,19 @@ export async function setPassword(pw: string) {
 
 export function getKey() { return key; }
 
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
 export async function encryptText(k: CryptoKey, text: string): Promise<string> {
   const enc = new TextEncoder();
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, k, enc.encode(text));
   const out = new Uint8Array(iv.length + ct.byteLength);
   out.set(iv, 0); out.set(new Uint8Array(ct), iv.length);
-  return btoa(String.fromCharCode(...out));
+  return bytesToBase64(out);
 }
 
 export async function decryptText(k: CryptoKey, data: string): Promise<string> {

--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -102,6 +102,10 @@
       } else {
         m.text = '[locked]';
       }
+      if (m.image && k) {
+        try { m.image = await decryptText(k, m.image); }
+        catch { m.image = ''; }
+      }
       m.showTime = false;
     }
     if (more) convo = [...list, ...convo];
@@ -113,14 +117,19 @@
   async function send() {
     err = '';
     let ct = '';
+    let img = null;
     const k = getKey();
     if (msg.trim()) {
       if (!k) { err = 'missing key'; return; }
       ct = await encryptText(k, msg);
     }
+    if (imageData) {
+      if (!k) { err = 'missing key'; return; }
+      img = await encryptText(k, imageData);
+    }
     const res = await apiFetch('/api/messages', {
       method:'POST', headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ to: parseInt(id), content: ct, image: imageData })
+      body: JSON.stringify({ to: parseInt(id), content: ct, image: img })
     });
     if (res.ok) { msg=''; imageData=null; offset=0; await load(); }
     else { err = (await res.json()).error; }
@@ -147,6 +156,10 @@
               catch { d.text = '[decrypt error]'; }
             } else {
               d.text = '[locked]';
+            }
+            if (d.image && k) {
+              try { d.image = await decryptText(k, d.image); }
+              catch { d.image = ''; }
             }
             d.showTime = false;
             convo = [...convo, d];


### PR DESCRIPTION
## Summary
- encrypt and decrypt image attachments on send/receive

## Testing
- `npm test --silent`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6882830e426483218ea617c31cc2fbf0