### PR TITLE
Improve Messages page UX

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -1273,7 +1273,22 @@ func searchUsers(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
 		return
 	}
-	c.JSON(http.StatusOK, list)
+        c.JSON(http.StatusOK, list)
+}
+
+func listConversations(c *gin.Context) {
+        limit := 20
+        if l := c.Query("limit"); l != "" {
+                if v, err := strconv.Atoi(l); err == nil {
+                        limit = v
+                }
+        }
+        list, err := ListRecentConversations(c.GetInt("userID"), limit)
+        if err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+                return
+        }
+        c.JSON(http.StatusOK, list)
 }
 
 func getUserPublic(c *gin.Context) {

--- a/backend/main.go
+++ b/backend/main.go
@@ -132,10 +132,11 @@ func main() {
 		api.GET("/users/:id", RoleGuard("student", "teacher", "admin"), getUserPublic)
 
 		// Messaging
-		api.GET("/user-search", RoleGuard("student", "teacher", "admin"), searchUsers)
-		api.POST("/messages", RoleGuard("student", "teacher", "admin"), createMessage)
-		api.GET("/messages/:id", RoleGuard("student", "teacher", "admin"), listMessages)
-		api.GET("/messages/events", RoleGuard("student", "teacher", "admin"), messageEventsHandler)
+               api.GET("/user-search", RoleGuard("student", "teacher", "admin"), searchUsers)
+               api.GET("/messages", RoleGuard("student", "teacher", "admin"), listConversations)
+               api.POST("/messages", RoleGuard("student", "teacher", "admin"), createMessage)
+               api.GET("/messages/:id", RoleGuard("student", "teacher", "admin"), listMessages)
+               api.GET("/messages/events", RoleGuard("student", "teacher", "admin"), messageEventsHandler)
 
 		// Class file system
 		api.GET("/classes/:id/files", RoleGuard("teacher", "student", "admin"), listClassFiles)

--- a/frontend/src/routes/messages/+page.svelte
+++ b/frontend/src/routes/messages/+page.svelte
@@ -1,29 +1,80 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { apiJSON } from '$lib/api';
   import type { User } from '$lib/auth';
   import { goto } from '$app/navigation';
+  import { getKey, decryptText } from '$lib/e2ee';
 
   let searchTerm = '';
   let results: User[] = [];
+  let convos: any[] = [];
+
+  onMount(() => { loadConvos(); });
+
+  async function loadConvos() {
+    const list = await apiJSON('/api/messages');
+    const k = getKey();
+    for (const c of list) {
+      if (c.content === '') {
+        c.text = '';
+      } else if (k) {
+        try { c.text = await decryptText(k, c.content); }
+        catch { c.text = '[decrypt error]'; }
+      } else {
+        c.text = '[locked]';
+      }
+    }
+    convos = list;
+  }
 
   async function search() {
     const r = await apiJSON(`/api/user-search?q=${encodeURIComponent(searchTerm)}`);
     results = Array.isArray(r) ? r : [];
   }
 
-  function openChat(u: User) {
+  function openChat(u: any) {
     const p = new URLSearchParams();
     if (u.name) p.set('name', u.name);
     else if (u.email) p.set('email', u.email);
-    goto(`/messages/${u.id}?${p.toString()}`);
+    const id = u.id ?? u.other_id;
+    goto(`/messages/${id}?${p.toString()}`);
   }
 </script>
 
 <h1 class="text-2xl font-bold mb-4">Messages</h1>
 <div class="mb-4 space-x-2">
-  <input class="input input-bordered" placeholder="Search" bind:value={searchTerm} />
+  <input
+    class="input input-bordered"
+    placeholder="Search"
+    bind:value={searchTerm}
+    on:keydown={(e) => e.key === 'Enter' && search()}
+  />
   <button class="btn" on:click={search}>Search</button>
 </div>
-{#each results as u}
-  <div class="mb-2"><button class="link" on:click={() => openChat(u)}>{u.name ?? u.email}</button></div>
-{/each}
+{#if results.length}
+  <h2 class="font-semibold mb-2">Search results</h2>
+  {#each results as u}
+    <div class="mb-2"><button class="link" on:click={() => openChat(u)}>{u.name ?? u.email}</button></div>
+  {/each}
+{/if}
+
+<div class="space-y-2 mt-4">
+  {#each convos as c}
+    <div class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-200 cursor-pointer" on:click={() => openChat(c)}>
+      <div class="avatar">
+        <div class="w-12 h-12 rounded-full overflow-hidden">
+          {#if c.avatar}
+            <img src={c.avatar} alt="Avatar" class="w-full h-full object-cover" />
+          {:else}
+            <img src="/placeholder.svg?height=48&width=48" alt="Avatar" />
+          {/if}
+        </div>
+      </div>
+      <div class="flex-1">
+        <div class="font-semibold">{c.name ?? c.email}</div>
+        <div class="text-sm opacity-70 truncate">{c.text || (c.image ? '[image]' : '')}</div>
+      </div>
+      <div class="text-xs opacity-60 whitespace-nowrap">{new Date(c.created_at).toLocaleString()}</div>
+    </div>
+  {/each}
+</div>

--- a/frontend/src/routes/messages/+page.svelte
+++ b/frontend/src/routes/messages/+page.svelte
@@ -36,7 +36,7 @@
     const p = new URLSearchParams();
     if (u.name) p.set('name', u.name);
     else if (u.email) p.set('email', u.email);
-    const id = u.id ?? u.other_id;
+    const id = u.other_id ?? u.id;
     goto(`/messages/${id}?${p.toString()}`);
   }
 </script>


### PR DESCRIPTION
## Summary
- show recent conversations with last messages
- decrypt last message preview client-side
- add server-side conversations endpoint
- wire up new route in API

## Testing
- `npm run check` *(fails: svelte-check found 15 errors and 43 warnings)*
- `npm run build` *(fails: invalid worker.format due to pyodide)*
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68828839417883219888875a8b201a66