### PR TITLE
Add client-side image compression

### DIFF
--- a/frontend/src/lib/image.ts
+++ b/frontend/src/lib/image.ts
@@ -1,0 +1,40 @@
+export async function compressImage(
+  file: File,
+  maxWidth = 1024,
+  quality = 0.8
+): Promise<File> {
+  if (!file.type.startsWith('image/')) return file;
+  return new Promise<File>((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const scale = Math.min(1, maxWidth / img.width);
+        const canvas = document.createElement('canvas');
+        canvas.width = img.width * scale;
+        canvas.height = img.height * scale;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          resolve(file);
+          return;
+        }
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        canvas.toBlob(
+          (blob) => {
+            if (!blob) {
+              resolve(file);
+              return;
+            }
+            resolve(new File([blob], file.name, { type: 'image/jpeg' }));
+          },
+          'image/jpeg',
+          quality
+        );
+      };
+      img.onerror = () => resolve(file);
+      img.src = reader.result as string;
+    };
+    reader.onerror = () => resolve(file);
+    reader.readAsDataURL(file);
+  });
+}

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -4,3 +4,4 @@ export { default as FileTree } from './FileTree.svelte';
 export { default as AdminPanel } from './AdminPanel.svelte';
 export { default as NotebookEditor } from './components/NotebookEditor.svelte';
 export * from './sse';
+export * from './image';

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
   import { apiFetch } from '$lib/api';
   import { sha256 } from '$lib/hash';
   import { initKey } from '$lib/e2ee';
+  import { compressImage } from '$lib/image';
 
   let settingsDialog: HTMLDialogElement;
   let passwordDialog: HTMLDialogElement;
@@ -32,12 +33,13 @@
     settingsDialog.showModal();
   }
 
-  function onAvatarChange(e: Event) {
+  async function onAvatarChange(e: Event) {
     const file = (e.target as HTMLInputElement).files?.[0];
     if (!file) { avatarFile = null; return; }
+    const compressed = await compressImage(file, 256, 0.8);
     const reader = new FileReader();
     reader.onload = () => { avatarFile = reader.result as string; };
-    reader.readAsDataURL(file);
+    reader.readAsDataURL(compressed);
   }
 
   function chooseAvatar() {

--- a/frontend/src/routes/classes/[id]/files/+page.svelte
+++ b/frontend/src/routes/classes/[id]/files/+page.svelte
@@ -5,6 +5,7 @@ import { goto } from '$app/navigation';
 import { get } from 'svelte/store';
 import { auth } from '$lib/auth';
 import { apiJSON, apiFetch } from '$lib/api';
+import { compressImage } from '$lib/image';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
 let id = $page.params.id;
@@ -120,6 +121,9 @@ function openUploadDialog() {
 
 async function doUpload() {
   if (!uploadFile) return;
+  if (isImage(uploadFile.name)) {
+    uploadFile = await compressImage(uploadFile);
+  }
   if (uploadFile.size > maxFileSize) {
     uploadErr = 'File exceeds 20 MB limit';
     return;


### PR DESCRIPTION
## Summary
- compress images before uploading them
- export new compression helper via `$lib`

## Testing
- `npm run check`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6882955435888321bb73002b4126de56