### PR TITLE
Add client-side image compression

### DIFF
--- a/frontend/src/lib/utils/compressImage.ts
+++ b/frontend/src/lib/utils/compressImage.ts
@@ -1,0 +1,35 @@
+export async function compressImage(file: File, maxDim = 1024, quality = 0.8): Promise<File> {
+  if (!file.type.startsWith('image/')) return file;
+  const dataUrl: string = await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+  const img: HTMLImageElement = await new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = reject;
+    image.src = dataUrl;
+  });
+  let { width, height } = img;
+  if (width > maxDim || height > maxDim) {
+    if (width > height) {
+      height = Math.round((height * maxDim) / width);
+      width = maxDim;
+    } else {
+      width = Math.round((width * maxDim) / height);
+      height = maxDim;
+    }
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return file;
+  ctx.drawImage(img, 0, 0, width, height);
+  const blob: Blob = await new Promise((resolve) => {
+    canvas.toBlob((b) => resolve(b as Blob), 'image/jpeg', quality);
+  });
+  return new File([blob], file.name.replace(/\.[^.]+$/, '.jpg'), { type: 'image/jpeg' });
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,7 +7,8 @@
   import { sidebarOpen, sidebarCollapsed } from '$lib/sidebar';
   import { apiFetch } from '$lib/api';
   import { sha256 } from '$lib/hash';
-  import { initKey } from '$lib/e2ee';
+import { initKey } from '$lib/e2ee';
+import { compressImage } from '$lib/utils/compressImage';
 
   let settingsDialog: HTMLDialogElement;
   let passwordDialog: HTMLDialogElement;
@@ -32,12 +33,13 @@
     settingsDialog.showModal();
   }
 
-  function onAvatarChange(e: Event) {
+  async function onAvatarChange(e: Event) {
     const file = (e.target as HTMLInputElement).files?.[0];
     if (!file) { avatarFile = null; return; }
+    const compressed = await compressImage(file, 512, 0.8);
     const reader = new FileReader();
     reader.onload = () => { avatarFile = reader.result as string; };
-    reader.readAsDataURL(file);
+    reader.readAsDataURL(compressed);
   }
 
   function chooseAvatar() {

--- a/frontend/src/routes/classes/[id]/files/+page.svelte
+++ b/frontend/src/routes/classes/[id]/files/+page.svelte
@@ -6,6 +6,7 @@ import { get } from 'svelte/store';
 import { auth } from '$lib/auth';
 import { apiJSON, apiFetch } from '$lib/api';
 import '@fortawesome/fontawesome-free/css/all.min.css';
+import { compressImage } from '$lib/utils/compressImage';
 
 let id = $page.params.id;
 $: if ($page.params.id !== id) { id = $page.params.id; load(currentParent); }
@@ -120,13 +121,19 @@ function openUploadDialog() {
 
 async function doUpload() {
   if (!uploadFile) return;
-  if (uploadFile.size > maxFileSize) {
+  let fileToUpload = uploadFile;
+  if (uploadFile.type.startsWith('image/')) {
+    try {
+      fileToUpload = await compressImage(uploadFile);
+    } catch {}
+  }
+  if (fileToUpload.size > maxFileSize) {
     uploadErr = 'File exceeds 20 MB limit';
     return;
   }
   const fd = new FormData();
   if (currentParent !== null) fd.append('parent_id', String(currentParent));
-  fd.append('file', uploadFile);
+  fd.append('file', fileToUpload);
   uploading = true;
   const res = await apiFetch(`/api/classes/${id}/files`, { method: 'POST', body: fd });
   if (!res.ok) {

--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -6,6 +6,7 @@
   import { createEventSource } from '$lib/sse';
   import { getKey, encryptText, decryptText } from '$lib/e2ee';
   import { auth } from '$lib/auth';
+  import { compressImage } from '$lib/utils/compressImage';
   import { ImagePlus, Send } from 'lucide-svelte';
 
   let id = $page.params.id;
@@ -179,12 +180,13 @@
   function back() { goto('/messages'); }
 
   function chooseFile() { fileInput?.click(); }
-  function fileChanged(e: Event) {
+  async function fileChanged(e: Event) {
     const f = (e.target as HTMLInputElement).files?.[0];
     if (!f) return;
+    const compressed = await compressImage(f, 1280, 0.8);
     const r = new FileReader();
     r.onload = () => { imageData = r.result as string; };
-    r.readAsDataURL(f);
+    r.readAsDataURL(compressed);
   }
 
   function openImage(src: string) {


### PR DESCRIPTION
## Summary
- compress images before uploading on the frontend
- add shared `compressImage` utility
- use compressed images for avatar upload
- compress images before sending chat messages
- compress image files uploaded to class folders

## Testing
- `npm test` *(fails: Missing script)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688297a3f49883219adf480c03990e9a