### PR TITLE
Add contact search page with avatars

### DIFF
--- a/backend/models.go
+++ b/backend/models.go
@@ -926,35 +926,36 @@ func ListMessages(userID, otherID, limit, offset int) ([]Message, error) {
 }
 
 type UserSearch struct {
-	ID    int     `db:"id" json:"id"`
-	Email string  `db:"email" json:"email"`
-	Name  *string `db:"name" json:"name"`
+	ID     int     `db:"id" json:"id"`
+	Email  string  `db:"email" json:"email"`
+	Name   *string `db:"name" json:"name"`
+	Avatar *string `db:"avatar" json:"avatar"`
 }
 
 func SearchUsers(term string) ([]UserSearch, error) {
 	list := []UserSearch{}
 	like := "%" + term + "%"
-        err := DB.Select(&list,
-                `SELECT id,email,name FROM users
+	err := DB.Select(&list,
+		`SELECT id,email,name,avatar FROM users
                   WHERE LOWER(email) LIKE LOWER($1) OR LOWER(COALESCE(name,'')) LIKE LOWER($1)
                   ORDER BY email LIMIT 20`, like)
-        return list, err
+	return list, err
 }
 
 type Conversation struct {
-        OtherID int     `db:"other_id" json:"other_id"`
-        Name    *string `db:"name" json:"name"`
-        Avatar  *string `db:"avatar" json:"avatar"`
-        Email   string  `db:"email" json:"email"`
-        Message
+	OtherID int     `db:"other_id" json:"other_id"`
+	Name    *string `db:"name" json:"name"`
+	Avatar  *string `db:"avatar" json:"avatar"`
+	Email   string  `db:"email" json:"email"`
+	Message
 }
 
 func ListRecentConversations(userID, limit int) ([]Conversation, error) {
-        list := []Conversation{}
-        if limit <= 0 {
-                limit = 20
-        }
-        const q = `
+	list := []Conversation{}
+	if limit <= 0 {
+		limit = 20
+	}
+	const q = `
         SELECT other_id, u.name, u.avatar, u.email,
                m.id, m.sender_id, m.recipient_id, m.content, m.image, m.created_at
           FROM (
@@ -971,7 +972,6 @@ func ListRecentConversations(userID, limit int) ([]Conversation, error) {
          WHERE rn = 1
          ORDER BY m.created_at DESC
          LIMIT $2`
-        err := DB.Select(&list, q, userID, limit)
-        return list, err
+	err := DB.Select(&list, q, userID, limit)
+	return list, err
 }
-

--- a/frontend/src/routes/messages/+page.svelte
+++ b/frontend/src/routes/messages/+page.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { apiJSON } from '$lib/api';
-  import type { User } from '$lib/auth';
   import { goto } from '$app/navigation';
   import { getKey, decryptText } from '$lib/e2ee';
 
-  let searchTerm = '';
-  let results: User[] = [];
   let convos: any[] = [];
 
   onMount(() => { loadConvos(); });
@@ -27,11 +24,6 @@
     convos = list;
   }
 
-  async function search() {
-    const r = await apiJSON(`/api/user-search?q=${encodeURIComponent(searchTerm)}`);
-    results = Array.isArray(r) ? r : [];
-  }
-
   function openChat(u: any) {
     const p = new URLSearchParams();
     if (u.name) p.set('name', u.name);
@@ -42,21 +34,13 @@
 </script>
 
 <h1 class="text-2xl font-bold mb-4">Messages</h1>
-<div class="mb-4 space-x-2">
+<div class="mb-4">
   <input
     class="input input-bordered"
-    placeholder="Search"
-    bind:value={searchTerm}
-    on:keydown={(e) => e.key === 'Enter' && search()}
+    placeholder="Search users"
+    on:input={(e) => goto(`/messages/search?q=${encodeURIComponent((e.target as HTMLInputElement).value)}`)}
   />
-  <button class="btn" on:click={search}>Search</button>
 </div>
-{#if results.length}
-  <h2 class="font-semibold mb-2">Search results</h2>
-  {#each results as u}
-    <div class="mb-2"><button class="link" on:click={() => openChat(u)}>{u.name ?? u.email}</button></div>
-  {/each}
-{/if}
 
 <div class="space-y-2 mt-4">
   {#each convos as c}

--- a/frontend/src/routes/messages/+page.svelte
+++ b/frontend/src/routes/messages/+page.svelte
@@ -36,7 +36,7 @@
 <h1 class="text-2xl font-bold mb-4">Messages</h1>
 <div class="mb-4">
   <input
-    class="input input-bordered"
+    class="input input-bordered w-full sm:max-w-xs"
     placeholder="Search users"
     on:input={(e) => goto(`/messages/search?q=${encodeURIComponent((e.target as HTMLInputElement).value)}`)}
   />

--- a/frontend/src/routes/messages/search/+page.svelte
+++ b/frontend/src/routes/messages/search/+page.svelte
@@ -38,7 +38,7 @@
 <h1 class="text-2xl font-bold mb-4">New message</h1>
 <div class="mb-4">
   <input
-    class="input input-bordered w-full"
+    class="input input-bordered w-full sm:max-w-xs"
     placeholder="Search"
     bind:value={searchTerm}
     bind:this={inputEl}

--- a/frontend/src/routes/messages/search/+page.svelte
+++ b/frontend/src/routes/messages/search/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { apiJSON } from '$lib/api';
+  import type { User } from '$lib/auth';
+
+  let searchTerm = $page.url.searchParams.get('q') ?? '';
+  let results: User[] = [];
+  let inputEl: HTMLInputElement | null = null;
+
+  $: if (searchTerm.trim() !== '') {
+    fetchResults(searchTerm);
+  } else {
+    results = [];
+  }
+
+  async function fetchResults(q: string) {
+    const r = await apiJSON(`/api/user-search?q=${encodeURIComponent(q)}`);
+    results = Array.isArray(r) ? r : [];
+  }
+
+  function handleInput(e: Event) {
+    searchTerm = (e.target as HTMLInputElement).value;
+  }
+
+  onMount(() => { inputEl?.focus(); });
+
+  function openChat(u: any) {
+    const p = new URLSearchParams();
+    if (u.name) p.set('name', u.name);
+    else if (u.email) p.set('email', u.email);
+    const id = u.other_id ?? u.id;
+    goto(`/messages/${id}?${p.toString()}`);
+  }
+</script>
+
+<h1 class="text-2xl font-bold mb-4">New message</h1>
+<div class="mb-4">
+  <input
+    class="input input-bordered w-full"
+    placeholder="Search"
+    bind:value={searchTerm}
+    bind:this={inputEl}
+    on:input={handleInput}
+  />
+</div>
+
+<div class="space-y-2">
+  {#each results as u (u.id)}
+    {#if u}
+    <div class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-200 cursor-pointer" on:click={() => openChat(u)}>
+      <div class="avatar">
+        <div class="w-10 h-10 rounded-full overflow-hidden">
+          {#if u.avatar}
+            <img src={u.avatar} alt="Avatar" class="w-full h-full object-cover" />
+          {:else}
+            <img src="/placeholder.svg?height=40&width=40" alt="Avatar" />
+          {/if}
+        </div>
+      </div>
+      <div>{u.name ?? u.email}</div>
+    </div>
+    {/if}
+  {/each}
+</div>


### PR DESCRIPTION
## Summary
- add avatar to user search results on backend
- allow searching contacts in a dedicated page
- trigger search page from message index

## Testing
- `go test ./...`
- `npm run check` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_68829ec633e08321a154376b51f8ffaf