### PR TITLE
Add back button in chat header

### DIFF
--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -7,7 +7,7 @@
   import { getKey, encryptText, decryptText } from '$lib/e2ee';
   import { auth } from '$lib/auth';
   import { compressImage } from '$lib/utils/compressImage';
-  import { ImagePlus, Send } from 'lucide-svelte';
+  import { ImagePlus, Send, ChevronLeft } from 'lucide-svelte';
 
   let id = $page.params.id;
   $: if ($page.params.id !== id) {
@@ -195,10 +195,11 @@
   }
 </script>
 
-<button class="btn btn-sm mb-4" on:click={back}>Back</button>
-
 <div class="card bg-base-100 shadow fixed inset-x-0 bottom-0 top-16 sm:left-60 z-40 flex flex-col">
   <div class="p-4 border-b flex items-center gap-3">
+    <button class="btn btn-square" on:click={back} aria-label="Back">
+      <ChevronLeft class="w-4 h-4" />
+    </button>
     <div class="avatar">
       <div class="w-10 h-10 rounded-full overflow-hidden">
         {#if contactAvatar}

--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -197,7 +197,7 @@
 
 <div class="card bg-base-100 shadow fixed inset-x-0 bottom-0 top-16 sm:left-60 z-40 flex flex-col">
   <div class="p-4 border-b flex items-center gap-3">
-    <button class="btn btn-square" on:click={back} aria-label="Back">
+    <button class="btn btn-square btn-ghost" on:click={back} aria-label="Back">
       <ChevronLeft class="w-4 h-4" />
     </button>
     <div class="avatar">


### PR DESCRIPTION
## Summary
- add a ChevronLeft icon to the chat page
- move the Back button into the chat header

## Testing
- `npm run check` *(fails: svelte-check found 15 errors and 43 warnings)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6882a9fdcf488321a8c3e000cdae842b