### PR TITLE
Fix mobile sidebar overlap

### DIFF
--- a/frontend/src/lib/Sidebar.svelte
+++ b/frontend/src/lib/Sidebar.svelte
@@ -14,7 +14,7 @@
     } catch(e:any){ err = e.message }
   });
 </script>
-<div class={`fixed top-0 left-0 z-40 h-screen pointer-events-none group
+<div class={`fixed left-0 z-40 pointer-events-none group sm:top-0 sm:h-screen top-16 h-[calc(100dvh-4rem)]
     ${$sidebarOpen ? 'block' : 'hidden sm:block'}`}
 >
   <aside


### PR DESCRIPTION
## Summary
- adjust the sidebar top position on small screens so it appears below the sticky navbar

## Testing
- `go test ./...`
- `npm --prefix frontend run build` *(fails: Invalid value "iife" for option "worker.format")*

------
https://chatgpt.com/codex/tasks/task_e_6882aa8200b4832194e1b7cb0a413250