### PR TITLE
Add read receipt indicators

### DIFF
--- a/backend/message_events.go
+++ b/backend/message_events.go
@@ -51,6 +51,19 @@ func broadcastMsg(evt sse.Event) {
 	msgSubsMu.Unlock()
 }
 
+func broadcastRead(senderID, readerID int) {
+	msgSubsMu.Lock()
+	for sub := range msgSubs {
+		if sub.userID == senderID {
+			select {
+			case sub.ch <- sse.Event{Event: "read", Data: map[string]int{"reader_id": readerID}}:
+			default:
+			}
+		}
+	}
+	msgSubsMu.Unlock()
+}
+
 func messageEventsHandler(c *gin.Context) {
 	uid := c.GetInt("userID")
 	sub := addMsgSubscriber(uid)

--- a/backend/models.go
+++ b/backend/models.go
@@ -927,10 +927,16 @@ func ListMessages(userID, otherID, limit, offset int) ([]Message, error) {
 }
 
 func MarkMessagesRead(userID, otherID int) error {
-	_, err := DB.Exec(`UPDATE messages SET is_read=TRUE
+	res, err := DB.Exec(`UPDATE messages SET is_read=TRUE
                            WHERE sender_id=$1 AND recipient_id=$2 AND is_read=FALSE`,
 		otherID, userID)
-	return err
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		broadcastRead(otherID, userID)
+	}
+	return nil
 }
 
 type UserSearch struct {

--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -7,7 +7,7 @@
   import { getKey, encryptText, decryptText } from '$lib/e2ee';
   import { auth } from '$lib/auth';
   import { compressImage } from '$lib/utils/compressImage';
-  import { ImagePlus, Send, ChevronLeft } from 'lucide-svelte';
+  import { ImagePlus, Send, ChevronLeft, Check, CheckCheck } from 'lucide-svelte';
 
   let id = $page.params.id;
   $: if ($page.params.id !== id) {
@@ -171,6 +171,17 @@
             }
           }
         });
+        src.addEventListener('read', (ev) => {
+          const d = JSON.parse((ev as MessageEvent).data);
+          if (d.reader_id === parseInt(id)) {
+            for (const m of convo) {
+              if (m.sender_id === $auth?.id && m.recipient_id === parseInt(id)) {
+                m.is_read = true;
+              }
+            }
+            convo = [...convo];
+          }
+        });
       },
       {
         onError: (m) => { err = m; },
@@ -231,7 +242,7 @@
             <span class="text-xs bg-base-200 px-2 py-1 rounded-md">{formatDate(m.created_at)}</span>
           </div>
         {/if}
-        <div class={`flex ${m.sender_id === $auth?.id ? 'justify-end' : 'justify-start'} ${m.showTime ? 'mb-6' : ''}`}> 
+        <div class={`flex ${m.sender_id === $auth?.id ? 'justify-end' : 'justify-start'} ${(m.showTime || m.sender_id === $auth?.id) ? 'mb-6' : ''}`}>
           <div class="flex gap-2 max-w-[80%] items-end">
             {#if m.sender_id !== $auth?.id}
               <div class="avatar">
@@ -259,11 +270,16 @@
                   {hyphenateLongWords(m.text)}
                 </div>
               {/if}
-              {#if m.showTime}
-                <div class={`absolute mt-1 text-xs opacity-60 ${m.sender_id === $auth?.id ? 'right-0' : 'left-0'}`} style="top: calc(100%);">
-                  {formatTime(m.created_at)}
-                </div>
-              {/if}
+              <div class={`absolute mt-1 flex items-center gap-1 text-xs opacity-60 ${m.sender_id === $auth?.id ? 'right-0' : 'left-0'}`} style="top: calc(100%);">
+                {#if m.showTime}<span>{formatTime(m.created_at)}</span>{/if}
+                {#if m.sender_id === $auth?.id}
+                  {#if m.is_read}
+                    <CheckCheck class="w-3 h-3" />
+                  {:else}
+                    <Check class="w-3 h-3" />
+                  {/if}
+                {/if}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- broadcast `read` events from backend when messages get marked as read
- listen for `read` events on the message page and update conversation state
- show single and double check icons for sent/read messages

## Testing
- `go test ./...` *(fails: module download 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6882bc72f378832181bb8571a87ac5d0