### PR TITLE
Allow CodeMirror suggestions to overflow editor

### DIFF
--- a/frontend/src/lib/components/ui/CodeMirror.svelte
+++ b/frontend/src/lib/components/ui/CodeMirror.svelte
@@ -74,4 +74,4 @@ import { oneDark } from '@codemirror/theme-one-dark';
   }
 </script>
 
-<div bind:this={host} class="card-elevated" style="overflow: hidden"></div>
+<div bind:this={host} class="card-elevated" style="overflow: visible"></div>


### PR DESCRIPTION
## Summary
- change CodeMirror container overflow to visible so completion suggestions aren't clipped in small editors

## Testing
- `npm run check` *(fails: 13 errors, 27 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6895ff47143083219b77bc59d33a666b