### PR TITLE
Fix class name display in settings page

### DIFF
--- a/frontend/src/routes/classes/[id]/settings/+page.svelte
+++ b/frontend/src/routes/classes/[id]/settings/+page.svelte
@@ -43,8 +43,8 @@
     loading = true; err = ''; cls = null;
     try {
       const data = await apiJSON(`/api/classes/${id}`);
-      cls = data;
-      newName = data.name;
+      cls = data.class ?? data;
+      newName = cls.name;
       students = data.students ?? [];
       if (role === 'teacher' || role === 'admin') allStudents = await apiJSON('/api/students');
     } catch (e: any) { err = e.message }


### PR DESCRIPTION
## Summary
- ensure class settings page shows class name by extracting class details from API response

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check` (fails: svelte-check found 13 errors)
- `go test ./...` (no output, command terminated)


------
https://chatgpt.com/codex/tasks/task_e_6896639b480083218f56213d3e35263c