### PR TITLE
Match Bakalari accounts by last three UID characters

### DIFF
--- a/backend/auth.go
+++ b/backend/auth.go
@@ -257,9 +257,9 @@ func LoginBakalari(c *gin.Context) {
 	}
 	var bkUID *string
 	if uid := userInfo.UserUID; uid != "" {
-		if len(uid) >= 5 {
-			id5 := uid[len(uid)-5:]
-			bkUID = &id5
+		if len(uid) >= 3 {
+			id3 := uid[len(uid)-3:]
+			bkUID = &id3
 		} else {
 			bkUID = &uid
 		}

--- a/backend/models.go
+++ b/backend/models.go
@@ -292,6 +292,9 @@ func createStudentWithID(email, hash string, name, bkClass, bkUID *string) (int,
 // EnsureStudentForBk ensures a student exists for the given Bakaláři UID
 // and returns the local user ID.
 func EnsureStudentForBk(uid, cls, name string) (int, error) {
+	if len(uid) > 3 {
+		uid = uid[len(uid)-3:]
+	}
 	u, err := FindUserByBkUID(uid)
 	if err == nil {
 		if cls != "" && (u.BkClass == nil || *u.BkClass != cls) {


### PR DESCRIPTION
## Summary
- Trim Bakaláři user UID to its last three characters when logging in
- Normalize student IDs during import to compare using the same three-character suffix

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script "test")*
