### PR TITLE
feat: persist user theme preference

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -1273,6 +1273,7 @@ func updateProfile(c *gin.Context) {
 	var req struct {
 		Name   *string `json:"name"`
 		Avatar *string `json:"avatar"`
+		Theme  *string `json:"theme"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -1311,7 +1312,15 @@ func updateProfile(c *gin.Context) {
 			req.Avatar = &av
 		}
 	}
-	if err := UpdateUserProfile(uid, req.Name, req.Avatar); err != nil {
+	if req.Theme != nil {
+		t := strings.ToLower(strings.TrimSpace(*req.Theme))
+		if t != "light" && t != "dark" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid theme"})
+			return
+		}
+		req.Theme = &t
+	}
+	if err := UpdateUserProfile(uid, req.Name, req.Avatar, req.Theme); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
 		return
 	}
@@ -1456,68 +1465,68 @@ func listMessages(c *gin.Context) {
 }
 
 func markMessagesReadHandler(c *gin.Context) {
-        otherID, err := strconv.Atoi(c.Param("id"))
-        if err != nil {
-                c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
-                return
-        }
-        if err := MarkMessagesRead(c.GetInt("userID"), otherID); err != nil {
-                c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
-                return
-        }
-        c.Status(http.StatusNoContent)
+	otherID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := MarkMessagesRead(c.GetInt("userID"), otherID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
 func starConversation(c *gin.Context) {
-       id, err := strconv.Atoi(c.Param("id"))
-       if err != nil {
-               c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
-               return
-       }
-       if err := StarConversation(c.GetInt("userID"), id); err != nil {
-               c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
-               return
-       }
-       c.Status(http.StatusNoContent)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := StarConversation(c.GetInt("userID"), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
 func unstarConversation(c *gin.Context) {
-       id, err := strconv.Atoi(c.Param("id"))
-       if err != nil {
-               c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
-               return
-       }
-       if err := UnstarConversation(c.GetInt("userID"), id); err != nil {
-               c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
-               return
-       }
-       c.Status(http.StatusNoContent)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := UnstarConversation(c.GetInt("userID"), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
 func archiveConversation(c *gin.Context) {
-       id, err := strconv.Atoi(c.Param("id"))
-       if err != nil {
-               c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
-               return
-       }
-       if err := ArchiveConversation(c.GetInt("userID"), id); err != nil {
-               c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
-               return
-       }
-       c.Status(http.StatusNoContent)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := ArchiveConversation(c.GetInt("userID"), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
 func unarchiveConversation(c *gin.Context) {
-       id, err := strconv.Atoi(c.Param("id"))
-       if err != nil {
-               c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
-               return
-       }
-       if err := UnarchiveConversation(c.GetInt("userID"), id); err != nil {
-               c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
-               return
-       }
-       c.Status(http.StatusNoContent)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := UnarchiveConversation(c.GetInt("userID"), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db fail"})
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
 func blockUser(c *gin.Context) {

--- a/backend/main.go
+++ b/backend/main.go
@@ -95,7 +95,7 @@ func main() {
 			if u.Avatar == nil {
 				pick := defaultAvatars[rand.Intn(len(defaultAvatars))]
 				// best-effort update; ignore error but reflect in response
-				_ = UpdateUserProfile(u.ID, nil, &pick)
+				_ = UpdateUserProfile(u.ID, nil, &pick, nil)
 				u.Avatar = &pick
 			}
 			c.JSON(http.StatusOK, gin.H{
@@ -105,6 +105,7 @@ func main() {
 				"avatar": u.Avatar,
 				"bk_uid": u.BkUID,
 				"email":  u.Email,
+				"theme":  u.Theme,
 			})
 		})
 		// expose default avatars catalog to the frontend
@@ -171,15 +172,15 @@ func main() {
 
 		// Messaging
 		api.GET("/user-search", RoleGuard("student", "teacher", "admin"), searchUsers)
-        api.GET("/messages", RoleGuard("student", "teacher", "admin"), listConversations)
-        api.POST("/messages", RoleGuard("student", "teacher", "admin"), createMessage)
-        api.GET("/messages/:id", RoleGuard("student", "teacher", "admin"), listMessages)
-        api.PUT("/messages/:id/read", RoleGuard("student", "teacher", "admin"), markMessagesReadHandler)
-        api.POST("/messages/:id/star", RoleGuard("student", "teacher", "admin"), starConversation)
-        api.DELETE("/messages/:id/star", RoleGuard("student", "teacher", "admin"), unstarConversation)
-        api.POST("/messages/:id/archive", RoleGuard("student", "teacher", "admin"), archiveConversation)
-        api.DELETE("/messages/:id/archive", RoleGuard("student", "teacher", "admin"), unarchiveConversation)
-        api.GET("/messages/events", RoleGuard("student", "teacher", "admin"), messageEventsHandler)
+		api.GET("/messages", RoleGuard("student", "teacher", "admin"), listConversations)
+		api.POST("/messages", RoleGuard("student", "teacher", "admin"), createMessage)
+		api.GET("/messages/:id", RoleGuard("student", "teacher", "admin"), listMessages)
+		api.PUT("/messages/:id/read", RoleGuard("student", "teacher", "admin"), markMessagesReadHandler)
+		api.POST("/messages/:id/star", RoleGuard("student", "teacher", "admin"), starConversation)
+		api.DELETE("/messages/:id/star", RoleGuard("student", "teacher", "admin"), unstarConversation)
+		api.POST("/messages/:id/archive", RoleGuard("student", "teacher", "admin"), archiveConversation)
+		api.DELETE("/messages/:id/archive", RoleGuard("student", "teacher", "admin"), unarchiveConversation)
+		api.GET("/messages/events", RoleGuard("student", "teacher", "admin"), messageEventsHandler)
 
 		// Class file system
 		api.GET("/classes/:id/files", RoleGuard("teacher", "student", "admin"), listClassFiles)

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS users (
   name TEXT,
   avatar TEXT,
   role TEXT NOT NULL DEFAULT 'student' CHECK (role IN ('student','teacher','admin')),
+  theme TEXT NOT NULL DEFAULT 'light' CHECK (theme IN ('light','dark')),
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -13,6 +14,7 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS name TEXT;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS bk_class TEXT;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS bk_uid TEXT;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS theme TEXT NOT NULL DEFAULT 'light' CHECK (theme IN ('light','dark'));
 
 
 CREATE TABLE IF NOT EXISTS classes (

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -9,6 +9,7 @@ export type User = {
   avatar?: string | null;
   email?: string | null;
   bk_uid?: string | null;
+  theme?: "light" | "dark" | null;
 } | null;
 
 function createAuth() {
@@ -23,8 +24,9 @@ function createAuth() {
     avatar?: string | null,
     bk_uid?: string | null,
     email?: string | null,
+    theme?: "light" | "dark" | null,
   ) {
-    set({ id, role, name, avatar, bk_uid, email });
+    set({ id, role, name, avatar, bk_uid, email, theme });
   }
 
   /** Log out everywhere */
@@ -36,7 +38,7 @@ function createAuth() {
         // ignore errors
       }
       try {
-        localStorage.removeItem('cg-msg-key');
+        localStorage.removeItem("cg-msg-key");
       } catch {}
     }
     set(null);
@@ -56,6 +58,7 @@ function createAuth() {
         me.avatar ?? null,
         me.bk_uid ?? null,
         me.email ?? null,
+        me.theme ?? null,
       );
     } else {
       logout();

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -33,7 +33,7 @@
       await setPassword(password)
 
       // 3. Store & smart-redirect
-      auth.login(me.id, me.role, me.name ?? null, me.avatar ?? null, me.bk_uid ?? null, me.email ?? null)
+      auth.login(me.id, me.role, me.name ?? null, me.avatar ?? null, me.bk_uid ?? null, me.email ?? null, me.theme ?? null)
       goto('/dashboard')
     }
     async function submitBk() {
@@ -54,7 +54,7 @@
       }
       const me = await meRes.json()
       await setPassword(bkPass)
-      auth.login(me.id, me.role, me.name ?? null, me.avatar ?? null, me.bk_uid ?? null, me.email ?? null)
+      auth.login(me.id, me.role, me.name ?? null, me.avatar ?? null, me.bk_uid ?? null, me.email ?? null, me.theme ?? null)
       goto('/dashboard')
     }
   </script>


### PR DESCRIPTION
## Summary
- remember each user's light or dark mode preference in the database
- expose theme on `/api/me` and allow updating it
- let the UI toggle theme and sync it with the backend

## Testing
- `go test ./...`
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run check` *(fails: svelte-check found 13 errors and 28 warnings in 14 files)*

------
https://chatgpt.com/codex/tasks/task_e_6897550a94948321bb2dfcb0a58268e9