### PR TITLE
Fix Files link in class overview

### DIFF
--- a/frontend/src/routes/classes/[id]/overview/+page.svelte
+++ b/frontend/src/routes/classes/[id]/overview/+page.svelte
@@ -81,7 +81,7 @@ function badgeFor(a: any) {
       <p class="opacity-70 text-sm">Teacher: {cls.teacher.name ?? cls.teacher.email}</p>
     </div>
     <div class="hidden sm:flex gap-2">
-      <a href={`/classes/${cls.id}/files`} class="btn btn-outline"><FolderOpen class="w-4 h-4" aria-hidden="true" /> Files</a>
+      <a href={`/classes/${id}/files`} class="btn btn-outline"><FolderOpen class="w-4 h-4" aria-hidden="true" /> Files</a>
       <a href="/messages" class="btn btn-outline"><MessageSquare class="w-4 h-4" aria-hidden="true" /> Messages</a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Ensure "Files" button on class overview links to `/classes/[id]/files`

## Testing
- `npm run check` *(fails: No overload matches this call & other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68976abe361c8321b347f6befeb7c52f