### PR TITLE
feat: show neutral message when deadline passed

### DIFF
--- a/frontend/src/routes/assignments/[id]/+page.svelte
+++ b/frontend/src/routes/assignments/[id]/+page.svelte
@@ -70,6 +70,15 @@ $: safeDesc = assignment ? DOMPurify.sanitize(marked.parse(assignment.descriptio
   $: isOverdue = assignment ? new Date(assignment.deadline) < new Date() : false
   $: timeUntilDeadline = assignment ? new Date(assignment.deadline).getTime() - Date.now() : 0
   $: deadlineSoon = timeUntilDeadline > 0 && timeUntilDeadline <= 24 * 60 * 60 * 1000
+  $: deadlineBadgeClass = isOverdue && !(role==='student' && done) ? 'badge-error' : 'badge-ghost'
+  $: deadlineLabel = assignment ? (
+      isOverdue
+        ? (role==='student' && done
+            ? `Deadline passed ${relativeToDeadline(assignment.deadline)}`
+            : `Due ${relativeToDeadline(assignment.deadline)}`
+          )
+        : `Due ${relativeToDeadline(assignment.deadline)}`
+    ) : ''
 
   async function publish(){
     try{
@@ -362,7 +371,7 @@ $: safeDesc = assignment ? DOMPurify.sanitize(marked.parse(assignment.descriptio
             {/if}
           </div>
           <div class="mt-3 flex flex-wrap items-center gap-2">
-            <span class={`badge ${isOverdue ? 'badge-error' : 'badge-ghost'}`}>{isOverdue ? 'Due' : 'Due'} {relativeToDeadline(assignment.deadline)}</span>
+            <span class={`badge ${deadlineBadgeClass}`}>{deadlineLabel}</span>
             <span class="badge badge-ghost">Max {assignment.max_points} pts</span>
             <span class="badge badge-ghost">{policyLabel(assignment.grading_policy)}</span>
             {#if role!=='student'}


### PR DESCRIPTION
## Summary
- avoid labeling completed assignments as late once deadline has passed

## Testing
- `go test ./...`
- `npm --prefix frontend run check` *(fails: svelte-check found 13 errors and 26 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68978384bc6083218802928dcc71f087