### PR TITLE
feat: link recent class submissions to detail

### DIFF
--- a/frontend/src/routes/classes/[id]/overview/+page.svelte
+++ b/frontend/src/routes/classes/[id]/overview/+page.svelte
@@ -193,9 +193,18 @@ function badgeFor(a: any) {
         <h3 class="font-semibold mb-3">Recent submissions</h3>
         <ul class="space-y-2">
           {#each recentSubmissions as s}
-            <li class="flex items-center justify-between text-sm">
-              <span class="truncate">{cls.assignments.find((a:any)=>a.id===s.assignment_id)?.title}</span>
-              <span class="opacity-70 whitespace-nowrap">{formatDateTime(s.created_at)}</span>
+            <li>
+              <a
+                href={`/submissions/${s.id}`}
+                class="flex items-center justify-between text-sm hover:opacity-90"
+              >
+                <span class="truncate"
+                  >{cls.assignments.find((a:any) => a.id === s.assignment_id)?.title}</span
+                >
+                <span class="opacity-70 whitespace-nowrap"
+                  >{formatDateTime(s.created_at)}</span
+                >
+              </a>
             </li>
           {/each}
           {#if !recentSubmissions.length}


### PR DESCRIPTION
## Summary
- make recent submissions in class overview page clickable

## Testing
- `go test ./...`
- `npm --prefix frontend run check` *(fails: svelte-check found 13 errors and 26 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689783b0f984832180f5086929d24a4b