### PR TITLE
Avoid calling completed assignments 'late'

### DIFF
--- a/frontend/src/routes/classes/[id]/assignments/+page.svelte
+++ b/frontend/src/routes/classes/[id]/assignments/+page.svelte
@@ -34,9 +34,9 @@
     return () => clearInterval(t);
   });
 
-  function countdown(deadline: string) {
+  function countdown(deadline: string, completed?: boolean) {
     const diff = new Date(deadline).getTime() - now;
-    if (diff <= 0) return 'late';
+    if (diff <= 0) return completed ? 'deadline passed' : 'late';
     const d = Math.floor(diff / 86400000);
     if (d >= 1) return `${d}d`;
     const h = Math.floor(diff / 3600000);
@@ -162,7 +162,7 @@
                     <div class="text-sm opacity-70 flex items-center gap-2">
                       <span class={new Date(a.deadline) < new Date() && !a.completed ? 'text-error' : ''}>{formatDateTime(a.deadline)}</span>
                       <span>·</span>
-                      <span>{countdown(a.deadline)}</span>
+                      <span>{countdown(a.deadline, a.completed)}</span>
                     </div>
                   </div>
                   <div class="flex items-center gap-3 shrink-0">


### PR DESCRIPTION
## Summary
- Show a neutral "deadline passed" countdown for completed assignments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: svelte-check found 13 errors and 26 warnings in 13 files)*

------
https://chatgpt.com/codex/tasks/task_e_689790e78c4c83219a6d84ea3b18e618