### PR TITLE
fix: avoid chromium nav ghosting

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -153,38 +153,45 @@ body.hide-navbar .navbar {
 .appbar {
   position: relative;
   border-radius: 1rem;
-  /* Clear glass plate base */
-  background: rgba(255, 255, 255, 0.58);
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  backdrop-filter: blur(16px) saturate(160%);
-  -webkit-backdrop-filter: blur(16px) saturate(160%);
   /* Stronger, layered drop shadows to increase protrusion */
   box-shadow:
     0 10px 10px rgba(0, 0, 0, 0.10),
     0 10px 10px rgba(0, 0, 0, 0.14),
     inset 0 1px 0 rgba(255, 255, 255, 0.521);
-  /* Contain painting and isolate stacking to avoid ghosting artifacts */
   /* Prevent child blending artifacts with page content */
-  isolation: isolate;
+  /* Avoid paint containment to fix duplicate rendering in Chromium */
   overflow: hidden;
-  contain: paint;
+}
+
+/* Glass backdrop moved to pseudo-element to avoid Chromium ghosting */
+.appbar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: rgba(255, 255, 255, 0.58);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(16px) saturate(160%);
+  -webkit-backdrop-filter: blur(16px) saturate(160%);
 }
 
 /* Dark theme glass plate adjustments */
 [data-theme='dark'] .appbar {
-  background: rgba(16, 22, 28, 0.62);
-  border-color: rgba(255, 255, 255, 0.08);
   box-shadow:
     0 10px 22px rgba(0, 0, 0, 0.35),
     0 34px 70px rgba(0, 0, 0, 0.45),
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
   filter: drop-shadow(0 8px 16px rgba(0,0,0,0.15)) drop-shadow(0 36px 56px rgba(0,0,0,0.35));
 }
+[data-theme='dark'] .appbar::before {
+  background: rgba(16, 22, 28, 0.62);
+  border-color: rgba(255, 255, 255, 0.08);
+}
 
 /* Light theme: make glass extra glossy/shiny */
 [data-theme='light'] .appbar {
-  background: rgba(255, 255, 255, 0.32);
-  border-color: rgba(255, 255, 255, 0.34);
   box-shadow:
     0 12px 24px rgba(0, 0, 0, 0.02),
     0 40px 80px rgba(0, 0, 0, 0.06),
@@ -192,10 +199,18 @@ body.hide-navbar .navbar {
     inset 0 18px 40px rgba(255, 255, 255, 0.01);
   filter: drop-shadow(0 10px 16px rgba(0,0,0,0.02)) drop-shadow(0 48px 64px rgba(0,0,0,0.04));
 }
+[data-theme='light'] .appbar::before {
+  background: rgba(255, 255, 255, 0.32);
+  border-color: rgba(255, 255, 255, 0.34);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
 
-.appbar::before {
+.appbar::after {
   content: "";
-  position: absolute; inset: 0; border-radius: inherit; pointer-events: none;
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
   background:
     linear-gradient(180deg, rgba(255,255,255,0.16), rgba(255,255,255,0.06) 24%, rgba(255,255,255,0.02) 52%, transparent 72%),
     radial-gradient(120% 60% at 50% -10%, rgba(255,255,255,0.16), transparent 60%);
@@ -204,7 +219,7 @@ body.hide-navbar .navbar {
 }
 
 /* Light theme: stronger specular highlights and diagonal sheen */
-[data-theme='light'] .appbar::before {
+[data-theme='light'] .appbar::after {
   background:
     /* top-to-bottom glossy curve */
     linear-gradient(180deg, rgba(255,255,255,0.22), rgba(255,255,255,0.10) 26%, rgba(255,255,255,0.04) 54%, transparent 76%),
@@ -214,19 +229,6 @@ body.hide-navbar .navbar {
     radial-gradient(120% 60% at 50% -10%, rgba(255,255,255,0.20), transparent 60%),
     /* small sparkle near top-left */
     radial-gradient(40% 24% at 16% 2%, rgba(255,255,255,0.24), transparent 70%);
-}
-
-.appbar::after {
-  content: "";
-  position: absolute; inset: 0; border-radius: inherit; pointer-events: none;
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
-}
-
-/* Light theme: subtle polished edge */
-[data-theme='light'] .appbar::after {
-  border-color: rgba(0, 0, 0, 0.04);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 /* Normalize blend mode for all children to prevent text deformation through compositing */


### PR DESCRIPTION
## Summary
- move appbar blur/background to pseudo-element to stop Chromium from double-rendering the CodeGrader title

## Testing
- `npm run check` *(fails: 'u' is possibly 'null', 13 errors, 26 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6897a5b4cb448321895609f88515703b