### PR TITLE
Move Bakalari integration to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ The backend expects several variables to be set (usually via a `.env` file):
 - `JWT_SECRET` – secret used to sign authentication tokens
 - `ADMIN_EMAIL` – email for the seeded administrator account
 - `ADMIN_PASSWORD` – password for the seeded administrator account
-- `BAKALARI_BASE_URL` – base URL of the Bakaláři API v3 instance
+- `VITE_BAKALARI_BASE_URL` – base URL of the Bakaláři API v3 instance
 
 When this variable is configured, the frontend login page presents a
-"Bakalari" tab allowing students and teachers to authenticate using their
-school credentials.
+"Bakalari" tab that communicates with Bakaláři directly so credentials are
+never sent to the Code Grader server.
 
 You can copy `backend/.env.example` and adjust it for your environment.
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -137,7 +137,6 @@ func main() {
 		// TEACHER / STUDENT common
 		api.GET("/classes", RoleGuard("teacher", "student"), myClasses)
 		api.POST("/classes/:id/students", RoleGuard("teacher", "admin"), addStudents)
-		api.POST("/bakalari/atoms", RoleGuard("teacher"), bakalariAtoms)
 		api.POST("/classes/:id/import-bakalari", RoleGuard("teacher"), importBakalariStudents)
 		api.GET("/classes/all", RoleGuard("admin"), listAllClasses) // new
 

--- a/frontend/src/lib/bakalari.ts
+++ b/frontend/src/lib/bakalari.ts
@@ -1,0 +1,45 @@
+const BASE = import.meta.env.VITE_BAKALARI_BASE_URL as string;
+
+export async function login(username: string, password: string) {
+  const form = new URLSearchParams();
+  form.set('client_id', 'ANDR');
+  form.set('grant_type', 'password');
+  form.set('username', username);
+  form.set('password', password);
+  const res = await fetch(`${BASE}/api/login`, {
+    method: 'POST',
+    body: form
+  });
+  if (!res.ok) throw new Error('invalid credentials');
+  const { access_token } = await res.json();
+  const infoRes = await fetch(`${BASE}/api/3/user`, {
+    headers: { Authorization: `Bearer ${access_token}` }
+  });
+  if (!infoRes.ok) throw new Error('invalid credentials');
+  const info = await infoRes.json();
+  return { token: access_token as string, info };
+}
+
+export async function getAtoms(token: string) {
+  const res = await fetch(`${BASE}/api/3/marking/atoms`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  if (!res.ok) throw new Error('bakalari request failed');
+  const data = await res.json();
+  return data.Atoms as { Id: string; Name: string }[];
+}
+
+export async function getStudents(token: string, atomId: string) {
+  const res = await fetch(`${BASE}/api/3/marking/marks/${atomId}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  if (!res.ok) throw new Error('bakalari request failed');
+  const data = await res.json();
+  return data.Students as {
+    Id: string;
+    ClassId: string;
+    FirstName: string;
+    MiddleName: string;
+    LastName: string;
+  }[];
+}


### PR DESCRIPTION
## Summary
- shift Bakalari login and import workflows to the client and stop sending credentials to the server
- add TypeScript helper for Bakalari API calls
- update backend to accept Bakalari user info or student lists instead of credentials

## Testing
- `npm --prefix frontend run check` *(fails: 'u' is possibly 'null')*
- `cd backend && go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689b58bd98608321a46ea099832686ac