### PR TITLE
Fix noVNC proxy for GUI sessions

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -197,7 +198,11 @@ func main() {
 				return
 			}
 			// Build a proxy that points to container noVNC and explicitly set the path from the *path param
-			target, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", hostPort))
+			host := "127.0.0.1"
+			if _, err := net.ResolveIPAddr("ip", "host.docker.internal"); err == nil {
+				host = "host.docker.internal"
+			}
+			target, _ := url.Parse(fmt.Sprintf("http://%s:%d", host, hostPort))
 			proxy := httputil.NewSingleHostReverseProxy(target)
 			proxy.Director = func(r *http.Request) {
 				p := c.Param("path")


### PR DESCRIPTION
## Summary
- Allow GUI containers to bind VNC web server on all interfaces
- Probe and proxy noVNC via `host.docker.internal` when available

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a1d6a5783c8321bce19ea797503b87