### PR TITLE
Fix noVNC path for GUI sessions

### DIFF
--- a/frontend/src/lib/components/RunConsole.svelte
+++ b/frontend/src/lib/components/RunConsole.svelte
@@ -52,7 +52,9 @@
               // Server indicates a GUI-capable session; embed noVNC and minimize terminal
               showGUI = true;
               guiBase = String(msg.base || '').replace(/[^\/]$/, '$&/');
-              guiUrl = `${guiBase}vnc.html?autoconnect=1&resize=scale&path=websockify`;
+              // noVNC expects an absolute WebSocket path, include guiBase
+              const wsPath = `${guiBase}websockify`;
+              guiUrl = `${guiBase}vnc.html?autoconnect=1&resize=scale&path=${encodeURIComponent(wsPath)}`;
               terminalCollapsed = true;
               break;
             case 'started':


### PR DESCRIPTION
## Summary
- ensure noVNC websocket path includes submission-specific base

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: svelte-check found 13 errors and 26 warnings in 13 files)


------
https://chatgpt.com/codex/tasks/task_e_68a1db7ab9a08321a36092fd85d98c4e