### PR TITLE
Align noVNC WebSocket path with websockify

### DIFF
--- a/frontend/src/lib/components/RunConsole.svelte
+++ b/frontend/src/lib/components/RunConsole.svelte
@@ -52,7 +52,9 @@
               // Server indicates a GUI-capable session; embed noVNC and minimize terminal
               showGUI = true;
               guiBase = String(msg.base || '').replace(/[^\/]$/, '$&/');
-              guiUrl = `${guiBase}vnc.html?autoconnect=1&resize=scale&path=websockify`;
+              // websockify listens on the root path, so noVNC must be pointed there
+              // by sending an empty `path` query parameter.
+              guiUrl = `${guiBase}vnc.html?autoconnect=1&resize=scale&path=`;
               terminalCollapsed = true;
               break;
             case 'started':


### PR DESCRIPTION
## Summary
- Point noVNC to websockify's root path instead of `/websockify`
- Document reasoning in RunConsole for clarity

## Testing
- `npm test --prefix frontend` *(fails: Missing script "test")*
- `npm run check --prefix frontend` *(fails: command terminated before completion)*
- `go test ./...` *(fails: hung, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dd3e201083218d54322db1a90db2