### PR TITLE
fix: avoid SSR document errors

### DIFF
--- a/frontend/src/routes/classes/[id]/forum/+page.svelte
+++ b/frontend/src/routes/classes/[id]/forum/+page.svelte
@@ -112,9 +112,11 @@
     connect();
     adjustHeight();
     document.addEventListener('click', handleClickOutside);
+    document.addEventListener('keydown', handleLightboxKeydown);
     return () => {
       esCtrl?.close();
       document.removeEventListener('click', handleClickOutside);
+      document.removeEventListener('keydown', handleLightboxKeydown);
     };
   });
 
@@ -155,12 +157,7 @@
     if (e.key === 'ArrowRight') showNextImage();
   }
 
-  // Attach keyboard navigation only while lightbox is open
-  $: if (lightboxOpen) {
-    document.addEventListener('keydown', handleLightboxKeydown);
-  } else {
-    document.removeEventListener('keydown', handleLightboxKeydown);
-  }
+  // Keyboard navigation is handled globally; handler checks lightboxOpen
 
   function formatTime(d: string | number | Date) {
     return new Date(d).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });

--- a/frontend/src/routes/messages/[id]/+page.svelte
+++ b/frontend/src/routes/messages/[id]/+page.svelte
@@ -278,13 +278,15 @@
     );
     adjustHeight();
     
-    // Add click outside handler
+    // Add click outside handler and global keydown listener
     document.addEventListener('click', handleClickOutside);
+    document.addEventListener('keydown', handleLightboxKeydown);
   });
 
-  onDestroy(() => { 
-    esCtrl?.close(); 
+  onDestroy(() => {
+    esCtrl?.close();
     document.removeEventListener('click', handleClickOutside);
+    document.removeEventListener('keydown', handleLightboxKeydown);
   });
   function back() { goto('/messages'); }
 
@@ -364,12 +366,7 @@
     if (e.key === 'ArrowRight') showNextImage();
   }
 
-  // Attach keyboard navigation only while lightbox is open
-  $: if (lightboxOpen) {
-    document.addEventListener('keydown', handleLightboxKeydown);
-  } else {
-    document.removeEventListener('keydown', handleLightboxKeydown);
-  }
+  // Keyboard navigation is handled globally; handler checks lightboxOpen
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter' && !e.shiftKey) {


### PR DESCRIPTION
## Summary
- guard lightbox keyboard handlers from running on server
- register keydown listeners only on client

## Testing
- `npm run check` (fails: svelte-check found 15 errors and 38 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a61b891d08832188725dc4838ac6af